### PR TITLE
Tfsec

### DIFF
--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -31,3 +31,14 @@ jobs:
     secrets:
       access_key: "${{secrets.access_key_prod}}"
       secret_key: "${{secrets.secret_key_prod}}"
+  tfsec:
+    name: tfsec PR commenter
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone repo
+        uses: actions/checkout@master
+      - name: tfsec
+        uses: aquasecurity/tfsec-pr-commenter-action@main
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          working_directory: terraform/

--- a/.github/workflows/tfsec-main.yml
+++ b/.github/workflows/tfsec-main.yml
@@ -1,0 +1,21 @@
+name: "TFSec main branch check"
+
+on:
+  push:
+    branches:
+      - "main"
+    paths:
+      - "terraform/**"
+      - ".github/workflows/tfsec-main.yml"
+
+jobs:
+  tfsec:
+    name: tfsec check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone repo
+        uses: actions/checkout@master
+      - name: tfsec
+        uses: aquasecurity/tfsec-action@main
+        with:
+          working_directory: terraform/

--- a/README.md
+++ b/README.md
@@ -23,3 +23,16 @@ GitHub Actions is the CI/CD platform of choice for minimal maintenance, plus it 
   * After that completes successfully, repeat for the next environment (test -> staging -> production)
 
 The `terraform.yml` workflow could be reused by other Git repositories, but may need to be enhanced with e.g. a continuous deployment option. 
+
+## tfsec
+
+This repository uses [tfsec](https://aquasecurity.github.io/tfsec/) to scan the terraform code for potential security issues.
+It can be run using Docker
+
+```sh
+docker run --rm -it -v "$(pwd):/src" aquasec/tfsec /src
+```
+
+It's also available via Chocolately + other package managers, but the Docker image seems to be more up to date.
+
+Individual rules can be ignored with a comment on the line above with the form `tfsec:ignore:<rule-name>` e.g. `tfsec:ignore:aws-dynamodb-enable-at-rest-encryption`.

--- a/terraform/backend/access_log_bucket.tf
+++ b/terraform/backend/access_log_bucket.tf
@@ -1,0 +1,58 @@
+# tfsec:ignore:aws-s3-enable-bucket-logging tfsec:ignore:aws-s3-enable-versioning
+resource "aws_s3_bucket" "state_access_log_bucket" {
+  bucket = "data-collection-service-tfstate-access-logs-production"
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        kms_master_key_id = aws_kms_key.state_bucket_encryption_key.arn
+        sse_algorithm     = "aws:kms"
+      }
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "terraform_state" {
+  bucket = aws_s3_bucket.state_access_log_bucket.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_policy" "allow_log_writes" {
+  bucket = aws_s3_bucket.example.id
+  policy = data.aws_iam_policy_document.allow_log_writes.json
+}
+
+data "aws_caller_identity" "current" {}
+
+data "aws_iam_policy_document" "allow_log_writes" {
+  statement {
+    principals {
+      type        = "Service"
+      identifiers = ["logging.s3.amazonaws.com"]
+    }
+
+    actions = [
+      "s3:PutObject"
+    ]
+
+    resources = [
+      "${aws_s3_bucket.state_access_log_bucket.arn}/*"
+    ]
+
+    condition {
+      test     = "ArnLike"
+      variable = "aws:SourceArn"
+      values   = [aws_s3_bucket.terraform_state.arn]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values   = [data.aws_caller_identity.current.account_id]
+    }
+  }
+}

--- a/terraform/backend/main.tf
+++ b/terraform/backend/main.tf
@@ -2,11 +2,23 @@ provider "aws" {
   region = "eu-west-1"
 }
 
+# TODO:tfsec Enable bucket encryption
+# TODO:tfsec Consider enabling access logging
+# tfsec:ignore:aws-s3-enable-bucket-encryption tfsec:ignore:aws-s3-encryption-customer-key tfsec:ignore:aws-s3-enable-bucket-logging
 resource "aws_s3_bucket" "terraform_state" {
   bucket = "data-collection-service-tfstate-production"
   lifecycle {
     prevent_destroy = true
   }
+}
+
+resource "aws_s3_bucket_public_access_block" "terraform_state" {
+  bucket = aws_s3_bucket.terraform_state.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
 }
 
 resource "aws_s3_bucket_versioning" "terraform_state" {
@@ -16,6 +28,8 @@ resource "aws_s3_bucket_versioning" "terraform_state" {
   }
 }
 
+# Encryption/recovery not required - lock not sensitive
+# tfsec:ignore:aws-dynamodb-enable-at-rest-encryption tfsec:ignore:aws-dynamodb-enable-recovery tfsec:ignore:aws-dynamodb-table-customer-key
 resource "aws_dynamodb_table" "terraform_state_lock" {
   name           = "tfstate-locks"
   read_capacity  = 1

--- a/terraform/modules/active_directory/ca_server.tf
+++ b/terraform/modules/active_directory/ca_server.tf
@@ -6,14 +6,16 @@ resource "aws_secretsmanager_secret_version" "ca_install_credentials" {
   })
 }
 
-# TODO:tfsec Use CMK for secrets manager
-# tfsec:ignore:aws-ssm-secret-use-customer-key
-resource "aws_secretsmanager_secret" "ca_install_credentials" {
-  name = "ldaps_ca_credentials"
+resource "aws_kms_key" "ad_secrets_key" {
+  enable_key_rotation = true
 }
 
-# TODO:tfsec Enable bucket encryption
-# TODO:tfsec Consider enabling access logging
+resource "aws_secretsmanager_secret" "ca_install_credentials" {
+  name       = "ldaps_ca_credentials"
+  kms_key_id = aws_kms_key.ad_secrets_key.arn
+}
+
+# Currenly used to store a CRL, so encryption + logging are not required
 # tfsec:ignore:aws-s3-enable-bucket-encryption tfsec:ignore:aws-s3-encryption-customer-key tfsec:ignore:aws-s3-enable-bucket-logging
 resource "aws_s3_bucket" "ldaps_crl_and_certs" {
   bucket = "data-collection-service-ldaps-crl-certs-${var.environment}"

--- a/terraform/modules/active_directory/management_server.tf
+++ b/terraform/modules/active_directory/management_server.tf
@@ -7,6 +7,12 @@ resource "aws_instance" "ad_management_server" {
   associate_public_ip_address = true
   get_password_data           = true
   iam_instance_profile        = aws_iam_instance_profile.ad_management_profile.name
+  metadata_options {
+    http_tokens = "required"
+  }
+  root_block_device {
+    encrypted = true
+  }
 
   tags = merge(var.default_tags, { name = "AD management server" })
 }

--- a/terraform/modules/active_directory/security_groups.tf
+++ b/terraform/modules/active_directory/security_groups.tf
@@ -18,11 +18,14 @@ resource "aws_security_group" "ad_management_server" {
     to_port   = 0
     protocol  = "-1"
 
+    # tfsec:ignore:aws-vpc-no-public-egress-sgr
     cidr_blocks = ["0.0.0.0/0"]
+    description = "Allow all egress"
   }
 }
 
 resource "aws_security_group_rule" "domain_controllers_to_ca_1" {
+  description       = "Directory Services to CA port 135"
   type              = "egress"
   from_port         = 135
   to_port           = 135
@@ -32,6 +35,7 @@ resource "aws_security_group_rule" "domain_controllers_to_ca_1" {
 }
 
 resource "aws_security_group_rule" "domain_controllers_to_ca_2" {
+  description       = "Directory Services to CA ports 49152+"
   type              = "egress"
   from_port         = 49152
   to_port           = 65535

--- a/terraform/modules/networking/subnet.tf
+++ b/terraform/modules/networking/subnet.tf
@@ -21,18 +21,20 @@ resource "aws_subnet" "ad_subnet" {
 }
 
 resource "aws_subnet" "ad_management_server" {
-  availability_zone       = data.aws_availability_zones.available.names[0]
-  cidr_block              = "10.0.224.0/24"
-  vpc_id                  = aws_vpc.vpc.id
+  availability_zone = data.aws_availability_zones.available.names[0]
+  cidr_block        = "10.0.224.0/24"
+  vpc_id            = aws_vpc.vpc.id
+  # tfsec:ignore:aws-ec2-no-public-ip-subnet Intentionally public
   map_public_ip_on_launch = true
   tags                    = var.default_tags
 }
 
 resource "aws_subnet" "ldaps_ca_server" {
-  availability_zone = data.aws_availability_zones.available.names[0]
-  cidr_block        = "10.0.225.0/24"
-  vpc_id            = aws_vpc.vpc.id
-  tags              = var.default_tags
+  availability_zone       = data.aws_availability_zones.available.names[0]
+  cidr_block              = "10.0.225.0/24"
+  vpc_id                  = aws_vpc.vpc.id
+  map_public_ip_on_launch = false
+  tags                    = var.default_tags
 }
 
 resource "aws_subnet" "nat_gateway" {


### PR DESCRIPTION
Replaces #2.

Fix/ignore the tfsec warnings in the current code. Ignored warnings we should consider looking at, opinions welcome:

* ~Terraform state bucket~
  * ~Enabling (server side) bucket encryption~
    * ~With a customer managed key~
  * ~Enabling access logging (which would go to another S3 bucket)~
* ldaps_crl_and_certs S3 bucket
  * Same as above
  * Does this have secrets in or is it just public keys and a CRL?
    * Edit: Treating as non-secret
* ~Secrets manager~
  * ~Use a CMK - not convinced this is useful at the moment, but we will probably want to do this eventually with different keys for different services~
* AD Management Server
  * Limiting egress - probably something to think about when we set up an egress proxy - what's the ticket number for that?

~It got me to add descriptions for the `domain_controllers_to_ca_` security group rules @hugh-emerson do you know what the ports are for?~

Note that this PR includes changes to the backend state bucket setup, which will presumably need to be applied manually.

I've added a tfsec CI job to PRs only, do we want it for the main branch too, and if so should it block deploys or be allowed to fail?

I can't run the terraform without an AWS key, so I'll let the CI check it.