### PR TITLE
Restrict ingress on VPC default ACL

### DIFF
--- a/terraform/modules/networking/variables.tf
+++ b/terraform/modules/networking/variables.tf
@@ -17,3 +17,8 @@ variable "vpc_cidr_block" {
 variable "environment" {
   type = string
 }
+
+variable "ssh_cidr_allowlist" {
+  description = "CIDR"
+  type        = list(string)
+}

--- a/terraform/modules/networking/vpc.tf
+++ b/terraform/modules/networking/vpc.tf
@@ -7,3 +7,100 @@ resource "aws_vpc" "vpc" {
     "Name" = "delta-vpc-${var.environment}"
   }
 }
+
+resource "aws_default_network_acl" "main" {
+  default_network_acl_id = aws_vpc.vpc.default_network_acl_id
+
+  # Allow all intra-VPC traffic
+  ingress {
+    protocol   = -1
+    rule_no    = 100
+    action     = "allow"
+    cidr_block = aws_vpc.vpc.cidr_block
+    from_port  = 0
+    to_port    = 0
+  }
+
+  # Allow HTTPS
+  ingress {
+    protocol   = "tcp"
+    rule_no    = 200
+    action     = "allow"
+    cidr_block = "0.0.0.0/0"
+    from_port  = 443
+    to_port    = 443
+  }
+
+  # Allow HTTP
+  # TODO: This rule should be removed once all ALBs accept traffic over HTTPS only
+  ingress {
+    protocol   = "tcp"
+    rule_no    = 210
+    action     = "allow"
+    cidr_block = "0.0.0.0/0"
+    from_port  = 80
+    to_port    = 80
+  }
+
+  # Allow SSH from allowlisted CIDRs
+  dynamic "ingress" {
+    for_each = var.ssh_cidr_allowlist
+    content {
+      protocol   = "tcp"
+      rule_no    = ingress.key + 300
+      action     = "allow"
+      cidr_block = ingress.value
+      from_port  = 22
+      to_port    = 22
+    }
+  }
+
+  # Allow Ephemeral ports
+  ingress {
+    protocol   = "tcp"
+    rule_no    = 1000
+    action     = "allow"
+    cidr_block = "0.0.0.0/0"
+    from_port  = 1024
+    to_port    = 65535
+  }
+
+  ingress {
+    protocol   = "udp"
+    rule_no    = 1001
+    action     = "allow"
+    cidr_block = "0.0.0.0/0"
+    from_port  = 1024
+    to_port    = 65535
+  }
+
+  ingress {
+    protocol   = "icmp"
+    rule_no    = 1002
+    action     = "allow"
+    cidr_block = "0.0.0.0/0"
+    from_port  = 0
+    to_port    = 0
+    icmp_code  = -1
+    icmp_type  = -1
+  }
+
+  egress {
+    protocol   = -1
+    rule_no    = 100
+    action     = "allow"
+    cidr_block = "0.0.0.0/0"
+    from_port  = 0
+    to_port    = 0
+  }
+
+  tags = {
+    "Name" = "vpc-default-acl-${var.environment}"
+  }
+
+  lifecycle {
+    ignore_changes = [
+      subnet_ids
+    ]
+  }
+}

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -27,7 +27,8 @@ provider "aws" {
 }
 
 module "networking" {
-  source         = "../modules/networking"
-  vpc_cidr_block = "10.30.0.0/16"
-  environment    = "prod"
+  source             = "../modules/networking"
+  vpc_cidr_block     = "10.30.0.0/16"
+  environment        = "prod"
+  ssh_cidr_allowlist = var.allowed_ssh_cidrs
 }

--- a/terraform/production/variables.tf
+++ b/terraform/production/variables.tf
@@ -8,3 +8,8 @@ variable "default_tags" {
     repository        = "https://github.com/communitiesuk/delta-common-infrastructure"
   }
 }
+
+variable "allowed_ssh_cidrs" {
+  type    = list(string)
+  default = ["31.221.86.178/32", "167.98.33.82/32", "82.163.115.98/32", "87.224.105.250/32", "87.224.18.46/32"]
+}

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -27,9 +27,10 @@ provider "aws" {
 }
 
 module "networking" {
-  source         = "../modules/networking"
-  vpc_cidr_block = "10.20.0.0/16"
-  environment    = "staging"
+  source             = "../modules/networking"
+  vpc_cidr_block     = "10.20.0.0/16"
+  environment        = "staging"
+  ssh_cidr_allowlist = var.allowed_ssh_cidrs
 }
 
 module "active_directory" {
@@ -75,7 +76,7 @@ module "bastion" {
   public_subnet_ids       = [for subnet in module.networking.public_subnets : subnet.id]
   instance_subnet_ids     = [for subnet in module.networking.private_subnets : subnet.id]
   admin_ssh_key_pair_name = aws_key_pair.bastion_ssh_key.key_name
-  external_allowed_cidrs  = ["31.221.86.178/32", "167.98.33.82/32", "82.163.115.98/32", "87.224.105.250/32", "87.224.18.46/32"]
+  external_allowed_cidrs  = var.allowed_ssh_cidrs
   instance_count          = 1
 
   tags_asg = var.default_tags

--- a/terraform/staging/variables.tf
+++ b/terraform/staging/variables.tf
@@ -8,3 +8,8 @@ variable "default_tags" {
     repository        = "https://github.com/communitiesuk/delta-common-infrastructure"
   }
 }
+
+variable "allowed_ssh_cidrs" {
+  type    = list(string)
+  default = ["31.221.86.178/32", "167.98.33.82/32", "82.163.115.98/32", "87.224.105.250/32", "87.224.18.46/32"]
+}

--- a/terraform/test/main.tf
+++ b/terraform/test/main.tf
@@ -91,9 +91,10 @@ module "jaspersoft" {
 }
 
 module "networking" {
-  source         = "../modules/networking"
-  vpc_cidr_block = "10.0.0.0/16"
-  environment    = "test"
+  source             = "../modules/networking"
+  vpc_cidr_block     = "10.0.0.0/16"
+  environment        = "test"
+  ssh_cidr_allowlist = var.allowed_ssh_cidrs
 }
 
 module "active_directory" {
@@ -132,7 +133,7 @@ module "bastion" {
   public_subnet_ids       = [for subnet in module.networking.public_subnets : subnet.id]
   instance_subnet_ids     = [for subnet in module.networking.private_subnets : subnet.id]
   admin_ssh_key_pair_name = aws_key_pair.bastion_ssh_key.key_name
-  external_allowed_cidrs  = ["31.221.86.178/32", "167.98.33.82/32", "82.163.115.98/32", "87.224.105.250/32", "87.224.18.46/32"]
+  external_allowed_cidrs  = var.allowed_ssh_cidrs
   instance_count          = 1
   dns_config = {
     zone_id = module.dns.delegated_zone_id

--- a/terraform/test/variables.tf
+++ b/terraform/test/variables.tf
@@ -18,3 +18,8 @@ variable "delegated_domain" {
   type    = string
   default = "internal.delta-test.ramchandani.dev"
 }
+
+variable "allowed_ssh_cidrs" {
+  type    = list(string)
+  default = ["31.221.86.178/32", "167.98.33.82/32", "82.163.115.98/32", "87.224.105.250/32", "87.224.18.46/32"]
+}


### PR DESCRIPTION
As mentioned on <https://digital.dclg.gov.uk/jira/browse/DT-23>

This is extra protection against misconfigured security groups, it is not supposed to replace them.

Allow:

* All egress, and ingress to ephemeral ports (>=1024) to allow replies back through (it's stateless)
* HTTPS
* HTTP
* SSH from allowed IPs
* ICMP because pinging things is useful sometimes

I've also just merged #17 which adds "Name" tags to the network resources that didn't have them already to make them easier to manage in the AWS console.