### PR TITLE
Apply hotfix to Jaspersoft server

### DIFF
--- a/terraform/modules/jaspersoft/README.md
+++ b/terraform/modules/jaspersoft/README.md
@@ -1,10 +1,65 @@
 # JasperReports Server
 
-Requires S3 bucket (var.jaspersoft_binaries_s3_bucket) in the current AWS account with JasperReports Server binaries in, currently expects 7.8.0 and the 7.8.1 Service Pack.
+Requires S3 bucket (var.jaspersoft_binaries_s3_bucket) in the current AWS account with JasperReports Server binaries in.
 
 ```sh
 aws s3api create-bucket --bucket dluhc-jaspersoft-bin --acl private --region eu-west-1 --create-bucket-configuration LocationConstraint=eu-west-1
 aws s3api put-bucket-versioning --bucket dluhc-jaspersoft-bin --versioning-configuration Status=Enabled
-aws s3 cp TIB_js-jrs-cp_7.8.0_bin.zip s3://dluhc-jaspersoft-bin
-aws s3 cp TIB_js-jrs_cp_7.8.1_sp.zip s3://dluhc-jaspersoft-bin
+```
+
+We've combined Jasper Reports Community edition 7.8.0, the 7.8.1 Service Pack and 2022-04-15 cumulative hotfix into one zip:
+
+```sh
+#!/bin/bash -ex
+# Extract archives
+unzip -q TIB_js-jrs-cp_7.8.0_bin.zip
+unzip -q TIB_js-jrs_cp_7.8.1_sp.zip -d js-sp-7.8.1
+unzip -q hotfix_jrspro7.8.1_cumulative_20220415_1823.zip -d js-hotfix-7.8.1
+# Update postgres driver
+rm jasperreports-server-cp-7.8.0-bin/buildomatic/conf_source/db/postgresql/jdbc/postgresql-42.2.5.jar
+wget -O jasperreports-server-cp-7.8.0-bin/buildomatic/conf_source/db/postgresql/jdbc/postgresql-42.5.0.jar "https://jdbc.postgresql.org/download/postgresql-42.5.0.jar"
+
+# Patch install tool
+## Service pack
+unzip -q js-sp-7.8.1/js-install.zip -d sp-js-install
+rsync -a sp-js-install/buildomatic/ jasperreports-server-cp-7.8.0-bin/buildomatic/
+## Hotfix
+unzip -q js-hotfix-7.8.1/js-install.zip -d hotfix-js-install
+rm hotfix-js-install/buildomatic/conf_source/iePro/applicationContext-adhoc.xml
+rm hotfix-js-install/buildomatic/conf_source/iePro/applicationContext-pro-remote-services.xml
+mv hotfix-js-install/buildomatic/conf_source/iePro hotfix-js-install/buildomatic/conf_source/ieCe
+cd jasperreports-server-cp-7.8.0-bin/buildomatic/
+rm conf_source/ieCe/lib/log4j-1.2-api-2.13.3.jar conf_source/ieCe/lib/log4j-api-2.13.3.jar conf_source/ieCe/lib/log4j-core-2.13.3.jar conf_source/ieCe/lib/log4j-jcl-2.13.3.jar conf_source/ieCe/lib/log4j-jul-2.13.3.jar conf_source/ieCe/lib/log4j-slf4j-impl-2.13.3.jar lib/log4j-1.2-api-2.13.3.jar lib/log4j-api-2.13.3.jar lib/log4j-core-2.13.3.jar lib/log4j-jcl-2.13.3.jar
+cd ../..
+rsync -a hotfix-js-install/buildomatic/ jasperreports-server-cp-7.8.0-bin/buildomatic/
+
+# Patch WAR
+## Service pack
+unzip -q jasperreports-server-cp-7.8.0-bin/jasperserver.war -d jasperreports-server-cp-7.8.0-bin/jasperserver
+unzip -q js-sp-7.8.1/jasperserver.zip -d war-sp
+rsync -a war-sp/ jasperreports-server-cp-7.8.0-bin/jasperserver/
+
+## Hotfix
+unzip -q js-hotfix-7.8.1/jasperserver-pro.zip -d war-hotfix
+cd war-hotfix/WEB-INF
+### Remove jasper pro specific files
+rm -r applicationContext-adhoc.xml applicationContext-pro-remote-services.xml applicationContext-security-pro-web.xml web.xml jsp/
+cd ../../jasperreports-server-cp-7.8.0-bin/jasperserver/WEB-INF/lib
+### Delete old log4j jars
+rm log4j-1.2-api-2.13.3.jar log4j-api-2.13.3.jar log4j-core-2.13.3.jar log4j-jcl-2.13.3.jar log4j-jul-2.13.3.jar log4j-slf4j-impl-2.13.3.jar log4j-web-2.13.3.jar
+cd ../../../..
+rsync -a war-hotfix/WEB-INF/ jasperreports-server-cp-7.8.0-bin/jasperserver/WEB-INF/
+
+## Recreate WAR
+rm jasperreports-server-cp-7.8.0-bin/jasperserver.war
+cd jasperreports-server-cp-7.8.0-bin/jasperserver/
+zip -q ../jasperserver.war -r *
+cd ..
+rm -r jasperserver
+
+# Zip back up
+zip -q ../js-7.8.1_hotfixed_2022-04-15.zip -r *
+cd ..
+# Upload
+aws s3 cp js-7.8.1_hotfixed_2022-04-15.zip s3://dluhc-jaspersoft-bin
 ```

--- a/terraform/modules/jaspersoft/install_files/default_master.properties
+++ b/terraform/modules/jaspersoft/install_files/default_master.properties
@@ -137,9 +137,9 @@ dbPassword=postgres
 # Uncomment and modify the value in order to change the default
 # Driver will be found here: <path>/buildomatic/conf_source/db/postgresql/jdbc
 #
-# maven.jdbc.groupId=org.postgresql
-# maven.jdbc.artifactId=postgresql
-# maven.jdbc.version=42.2.5
+maven.jdbc.groupId=org.postgresql
+maven.jdbc.artifactId=postgresql
+maven.jdbc.version=42.5.0
 
 
 # 2) Skip JDBC Driver Deploy

--- a/terraform/modules/jaspersoft/instance.tf
+++ b/terraform/modules/jaspersoft/instance.tf
@@ -61,6 +61,5 @@ resource "aws_instance" "jaspersoft_server" {
     aws_s3_object.jaspersoft_root_index_jsp,
     aws_s3_object.jaspersoft_root_web_xml,
     data.aws_s3_object.jaspersoft_install_zip,
-    data.aws_s3_object.jaspersoft_service_pack_zip,
   ]
 }

--- a/terraform/modules/jaspersoft/jaspersoft_install_bucket.tf
+++ b/terraform/modules/jaspersoft/jaspersoft_install_bucket.tf
@@ -4,12 +4,7 @@ data "aws_s3_bucket" "jaspersoft_binaries" {
 
 data "aws_s3_object" "jaspersoft_install_zip" {
   bucket = data.aws_s3_bucket.jaspersoft_binaries.bucket
-  key    = "TIB_js-jrs-cp_7.8.0_bin.zip"
-}
-
-data "aws_s3_object" "jaspersoft_service_pack_zip" {
-  bucket = data.aws_s3_bucket.jaspersoft_binaries.bucket
-  key    = "TIB_js-jrs_cp_7.8.1_sp.zip"
+  key    = "js-7.8.1_hotfixed_2022-04-15.zip"
 }
 
 resource "aws_iam_instance_profile" "read_jaspersoft_binaries" {

--- a/terraform/modules/jaspersoft/setup_script.sh
+++ b/terraform/modules/jaspersoft/setup_script.sh
@@ -3,6 +3,7 @@
 set -exuo pipefail
 
 export TOMCAT_VERSION=9.0.65
+export DEBIAN_FRONTEND=noninteractive
 
 # Let the instance finish booting
 
@@ -12,12 +13,17 @@ sleep 5
 
 # Setup
 
-apt update && apt upgrade -y
-apt install wget awscli lsb-release gnupg unzip -y
+apt-get update && apt-get upgrade -y
+apt-get install wget awscli lsb-release gnupg unzip -y
+
+# Block non-root users from accessing the instance metadata service
+iptables -A OUTPUT -m owner ! --uid-owner root -d 169.254.169.254 -j DROP
+echo iptables-persistent iptables-persistent/autosave_v4 boolean true | sudo debconf-set-selections
+apt-get install iptables-persistent -y
 
 # Install Java
 
-apt install openjdk-11-jdk -y
+apt-get install openjdk-11-jdk -y
 
 # Install Tomcat
 
@@ -25,7 +31,7 @@ rm -rf /opt/tomcat/base
 rm -rf /opt/tomcat/apache-tomcat-$${TOMCAT_VERSION}
 id -u tomcat &>/dev/null || useradd -m -U -d /opt/tomcat tomcat
 sudo -u tomcat mkdir -p /opt/tomcat/base
-wget "https://archive.apache.org/dist/tomcat/tomcat-9/v$${TOMCAT_VERSION}/bin/apache-tomcat-$${TOMCAT_VERSION}.tar.gz" -P /tmp
+wget -q "https://archive.apache.org/dist/tomcat/tomcat-9/v$${TOMCAT_VERSION}/bin/apache-tomcat-$${TOMCAT_VERSION}.tar.gz" -P /tmp
 sudo -u tomcat tar -xf /tmp/apache-tomcat-$${TOMCAT_VERSION}.tar.gz -C /opt/tomcat/
 rm -f /tmp/apache-tomcat-$${TOMCAT_VERSION}.tar.gz
 rm -f /opt/tomcat/latest
@@ -36,18 +42,19 @@ echo "export CATALINA_BASE=/opt/tomcat/base" >> /etc/profile.d/java-tomcat-vars.
 echo "export CATALINA_HOME=/opt/tomcat/latest" >> /etc/profile.d/java-tomcat-vars.sh
 source /etc/profile.d/java-tomcat-vars.sh
 
-sudo -u tomcat cp -r $${CATALINA_HOME}/conf/ $${CATALINA_BASE}/conf/
-sudo -u tomcat mkdir $${CATALINA_BASE}/webapps/
-sudo -u tomcat mkdir $${CATALINA_BASE}/logs
-sudo -u tomcat mkdir $${CATALINA_BASE}/temp
-sudo -u tomcat mkdir $${CATALINA_BASE}/work
-sudo -u tomcat mkdir $${CATALINA_BASE}/lib
+cp -r $${CATALINA_HOME}/conf/ $${CATALINA_BASE}/conf/
+mkdir $${CATALINA_BASE}/webapps/
+mkdir $${CATALINA_BASE}/logs
+mkdir $${CATALINA_BASE}/temp
+mkdir $${CATALINA_BASE}/work
+mkdir $${CATALINA_BASE}/lib
 
 # Setup a simple ROOT app that redirects to /jasperserver
-sudo -u tomcat mkdir $${CATALINA_BASE}/webapps/ROOT
-sudo -u tomcat mkdir $${CATALINA_BASE}/webapps/ROOT/WEB-INF
+mkdir $${CATALINA_BASE}/webapps/ROOT
+mkdir $${CATALINA_BASE}/webapps/ROOT/WEB-INF
 aws s3 cp s3://${JASPERSOFT_INSTALL_S3_BUCKET}/root_index.jsp $${CATALINA_BASE}/webapps/ROOT/index.jsp
 aws s3 cp s3://${JASPERSOFT_INSTALL_S3_BUCKET}/root_web.xml $${CATALINA_BASE}/webapps/ROOT/WEB-INF/web.xml
+chown -R tomcat:tomcat $${CATALINA_BASE}
 
 aws s3 cp s3://${JASPERSOFT_INSTALL_S3_BUCKET}/tomcat.service /etc/systemd/system/tomcat.service
 systemctl daemon-reload
@@ -58,39 +65,33 @@ systemctl enable tomcat
 echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list
 wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
 apt-get update
-DEBIAN_FRONTEND=noninteractive apt -y install postgresql-11
+apt-get -y install postgresql-11
 pg_ctlcluster 11 main start
 su postgres -c "psql -c \"ALTER USER postgres WITH PASSWORD 'postgres';\""
 
 # Download JasperSoft files
 
-su tomcat -c "aws s3 cp s3://${JASPERSOFT_INSTALL_S3_BUCKET}/TIB_js-jrs-cp_7.8.0_bin.zip /tmp"
-su tomcat -c "aws s3 cp s3://${JASPERSOFT_INSTALL_S3_BUCKET}/TIB_js-jrs_cp_7.8.1_sp.zip /tmp"
+aws s3 cp s3://${JASPERSOFT_INSTALL_S3_BUCKET}/js-7.8.1_hotfixed_2022-04-15.zip /tmp
 aws s3 cp s3://${JASPERSOFT_INSTALL_S3_BUCKET}/default_master.properties /tmp
 
 # We may also need to install Chrome, I haven't done this
 # > You need to install and configure Chrome/Chromium to export the reports to PDF and other output formats.
 
-# Unzip and apply service pack
-
-rm -rf /opt/tomcat/jaspersoft_install /opt/tomcat/jaspersoft_sp
-
-sudo -u tomcat unzip /tmp/TIB_js-jrs-cp_7.8.0_bin.zip -d /opt/tomcat/jaspersoft_install
-sudo -u tomcat unzip /tmp/TIB_js-jrs_cp_7.8.1_sp.zip -d /opt/tomcat/jaspersoft_sp
-sudo -u tomcat unzip /opt/tomcat/jaspersoft_sp/js-install.zip -d /opt/tomcat/jaspersoft_sp/js-install
-sudo -u tomcat rsync -a /opt/tomcat/jaspersoft_sp/js-install/buildomatic/ /opt/tomcat/jaspersoft_install/jasperreports-server-cp-7.8.0-bin/buildomatic/
-
-cd /opt/tomcat/jaspersoft_install/jasperreports-server-cp-7.8.0-bin/buildomatic
+# Set up install folder
+rm -rf /opt/tomcat/jaspersoft_install
+sudo -u tomcat unzip -q /tmp/js-7.8.1_hotfixed_2022-04-15.zip -d /tmp/jaspersoft_install
+sudo -u tomcat cp -r /tmp/jaspersoft_install /opt/tomcat/jaspersoft_install
+cd /opt/tomcat/jaspersoft_install/buildomatic
 cp /tmp/default_master.properties ./default_master.properties
-chown tomcat ./default_master.properties
+chown tomcat:tomcat ./default_master.properties
 
 # Run install
 su tomcat -c "./js-install-ce.sh minimal"
 
 # Fix for invalid CSRF header name, ALB will drop headers with underscores in
-sed -i 's/^org.owasp.csrfguard.TokenName=OWASP_CSRFTOKEN/org.owasp.csrfguard.TokenName=OWASPCSRFTOKEN/' /opt/tomcat/base/webapps/jasperserver/WEB-INF/csrf/jrs.csrfguard.properties
+sed -i 's/^org.owasp.csrfguard.TokenName=OWASP_CSRFTOKEN/org.owasp.csrfguard.TokenName=OWASPCSRFTOKEN/' $${CATALINA_BASE}/webapps/jasperserver/WEB-INF/csrf/jrs.csrfguard.properties
 
-sudo -u tomcat cp /opt/tomcat/jaspersoft_install/jasperreports-server-cp-7.8.0-bin/buildomatic/conf_source/db/postgresql/jdbc/postgresql-42.2.5.jar /opt/tomcat/base/lib/
+sudo -u tomcat cp /opt/tomcat/jaspersoft_install/buildomatic/conf_source/db/postgresql/jdbc/postgresql-42.5.0.jar $${CATALINA_BASE}/lib/
 
 systemctl start tomcat
 


### PR DESCRIPTION
It feels like there should be a better way to do this, but I couldn't find it.

This smooshes together 7.8.0, the 7.8.1 service pack, an updated Postgres driver and what I hope are the important bits of the hotfix. The hotfix is designed for the pro version and trying to apply the whole thing leaves you with a broken install.

I think it's worth considering putting this behind a login wall, once we have LDAP + KeyCloak that should be easy, and hopefully logging in twice with the same password isn't too big a deal.