### PR TITLE
Private Route53 zone

### DIFF
--- a/.github/workflows/roxy_deploy_marklogic_config.yml
+++ b/.github/workflows/roxy_deploy_marklogic_config.yml
@@ -18,26 +18,6 @@ on:
       - "DT-58"
 
 jobs:
-  get_terraform_outputs:
-    name: "Get Terraform outputs"
-    runs-on: ubuntu-latest
-    # unfortunately this means a reviewer needs to approve each job, even when a reviewer triggers the job
-    environment: staging # ${{ inputs.environment }}
-    outputs:
-      ml_hostname: ${{ steps.get_ml_hostname.outputs.ml_hostname }}
-    env:
-      AWS_ACCESS_KEY_ID: ${{ secrets.access_key }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.secret_key }}
-      AWS_REGION: "eu-west-1"
-    defaults:
-      run:
-        working-directory: terraform/staging # use inputs.environment once this is workflow_dispatch
-    steps:
-      - uses: actions/checkout@v3
-      - run: terraform init
-      - id: get_ml_hostname
-        run: echo "ml_hostname=$(terraform output -raw ml_hostname)" >> $GITHUB_OUTPUT
-
   deploy_ml:
     name: "Deploy MarkLogic config"
     runs-on: ["self-hosted", "staging"] # ${{ inputs.environment }}
@@ -45,7 +25,7 @@ jobs:
     environment: staging # ${{ inputs.environment }}
     env:
       # ml_* vars override Roxy's properties
-      ml_dluhc_server: ${{ needs.get_terraform_outputs.outputs.ml_hostname }}
+      ml_dluhc_server: marklogic.vpc.local
       ml_ldap_password: ${{ secrets.CPM_LDAP_PASSWORD }}
       ml_password: ${{ secrets.CPM_ML_ADMIN_PASSWORD }}
     defaults:

--- a/terraform/modules/active_directory/README.md
+++ b/terraform/modules/active_directory/README.md
@@ -7,7 +7,7 @@ To connect to the AD servers you will first need to forward port 3389 through th
 For setup see the top level README, then port forward with
 
 ```sh
-ssh <username>@$(terraform output -raw bastion_dns_name) -L localhost:3388:$(terraform output -raw ad_management_server_private_ip):3389
+ssh <username>@$(terraform output -raw bastion_dns_name) -L localhost:3388:ad_management.vpc.local:3389
 ```
 
 then connect with RDP to localhost:3388

--- a/terraform/modules/active_directory/management_server.tf
+++ b/terraform/modules/active_directory/management_server.tf
@@ -18,6 +18,14 @@ resource "aws_instance" "ad_management_server" {
   tags = { Name = "ad-management-server-${var.environment}" }
 }
 
+resource "aws_route53_record" "ad_management_server" {
+  zone_id = var.private_dns.zone_id
+  name    = "ad_management.${var.private_dns.base_domain}"
+  type    = "A"
+  ttl     = 60
+  records = [aws_instance.ad_management_server.private_ip]
+}
+
 resource "aws_ssm_document" "ad_management_server_setup" {
   name          = "ad-management-server-setup-${var.environment}"
   document_type = "Command"

--- a/terraform/modules/active_directory/variables.tf
+++ b/terraform/modules/active_directory/variables.tf
@@ -47,3 +47,10 @@ variable "rdp_ingress_sg_id" {
   description = "Id of security group to allow ingress to the AD Management server"
   type        = string
 }
+
+variable "private_dns" {
+  type = object({
+    zone_id     = string
+    base_domain = string
+  })
+}

--- a/terraform/modules/active_directory_dns_resolver/main.tf
+++ b/terraform/modules/active_directory_dns_resolver/main.tf
@@ -16,6 +16,11 @@ variable "vpc" {
   })
 }
 
+variable "dns_search" {
+  type    = string
+  default = null
+}
+
 locals {
   # Always at VPC CIDR base + 2, e.g. 10.0.0.2
   amazon_provided_vpc_dns = cidrhost(var.vpc.cidr_block, 2)
@@ -25,6 +30,7 @@ locals {
 
 resource "aws_vpc_dhcp_options" "dns_resolver" {
   domain_name_servers = local.dns_servers
+  domain_name         = var.dns_search
 }
 
 resource "aws_vpc_dhcp_options_association" "dns_resolver" {

--- a/terraform/modules/github_runner/instance.tf
+++ b/terraform/modules/github_runner/instance.tf
@@ -72,3 +72,11 @@ resource "aws_key_pair" "gh_runner" {
   key_name   = "gh-runner-key-${var.environment}"
   public_key = tls_private_key.gh_runner_ssh.public_key_openssh
 }
+
+resource "aws_route53_record" "gh_runner" {
+  zone_id = var.private_dns.zone_id
+  name    = "gh-runner.${var.private_dns.base_domain}"
+  type    = "A"
+  ttl     = 60
+  records = [aws_instance.gh_runner.private_ip]
+}

--- a/terraform/modules/github_runner/variables.tf
+++ b/terraform/modules/github_runner/variables.tf
@@ -26,3 +26,10 @@ variable "ssh_ingress_sg_id" {
   type        = string
   description = "Security id to allow SSH ingress from"
 }
+
+variable "private_dns" {
+  type = object({
+    zone_id     = string
+    base_domain = string
+  })
+}

--- a/terraform/modules/jaspersoft/instance.tf
+++ b/terraform/modules/jaspersoft/instance.tf
@@ -63,3 +63,11 @@ resource "aws_instance" "jaspersoft_server" {
     data.aws_s3_object.jaspersoft_install_zip,
   ]
 }
+
+resource "aws_route53_record" "jaspersoft_server" {
+  zone_id = var.private_dns.zone_id
+  name    = "jaspersoft.${var.private_dns.base_domain}"
+  type    = "A"
+  ttl     = 60
+  records = [aws_instance.jaspersoft_server.private_ip]
+}

--- a/terraform/modules/jaspersoft/variables.tf
+++ b/terraform/modules/jaspersoft/variables.tf
@@ -48,3 +48,10 @@ variable "java_max_heap" {
 variable "enable_backup" {
   type = bool
 }
+
+variable "private_dns" {
+  type = object({
+    zone_id     = string
+    base_domain = string
+  })
+}

--- a/terraform/modules/marklogic/load_balancing.tf
+++ b/terraform/modules/marklogic/load_balancing.tf
@@ -34,3 +34,15 @@ resource "aws_lb_listener" "ml" {
     target_group_arn = aws_lb_target_group.ml[count.index].arn
   }
 }
+
+resource "aws_route53_record" "marklogic_internal_nlb" {
+  zone_id = var.private_dns.zone_id
+  name    = "marklogic.${var.private_dns.base_domain}"
+  type    = "A"
+
+  alias {
+    name                   = aws_lb.ml_lb.dns_name
+    zone_id                = aws_lb.ml_lb.zone_id
+    evaluate_target_health = false
+  }
+}

--- a/terraform/modules/marklogic/variables.tf
+++ b/terraform/modules/marklogic/variables.tf
@@ -20,3 +20,10 @@ variable "instance_type" {
 variable "private_subnets" {
   description = "Three private subnets"
 }
+
+variable "private_dns" {
+  type = object({
+    zone_id     = string
+    base_domain = string
+  })
+}

--- a/terraform/modules/networking/outputs.tf
+++ b/terraform/modules/networking/outputs.tf
@@ -49,3 +49,10 @@ output "github_runner_private_subnet" {
   value       = aws_subnet.github_runner
   description = "Private /24 subnet for GitHub runner instance"
 }
+
+output "private_dns" {
+  value = {
+    zone_id     = aws_route53_zone.private.zone_id
+    base_domain = aws_route53_zone.private.name
+  }
+}

--- a/terraform/modules/networking/private_zone.tf
+++ b/terraform/modules/networking/private_zone.tf
@@ -1,0 +1,8 @@
+resource "aws_route53_zone" "private" {
+  name    = var.private_dns_domain
+  comment = "vpc-private-hosted-zone-${var.environment}"
+
+  vpc {
+    vpc_id = aws_vpc.vpc.id
+  }
+}

--- a/terraform/modules/networking/variables.tf
+++ b/terraform/modules/networking/variables.tf
@@ -22,3 +22,7 @@ variable "ssh_cidr_allowlist" {
   description = "CIDR"
   type        = list(string)
 }
+
+variable "private_dns_domain" {
+  default = "vpc.local"
+}

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -69,6 +69,7 @@ module "active_directory" {
   ldaps_ca_subnet              = module.networking.ldaps_ca_subnet
   environment                  = "staging"
   rdp_ingress_sg_id            = module.bastion.bastion_security_group_id
+  private_dns                  = module.networking.private_dns
 }
 
 module "active_directory_dns_resolver" {
@@ -76,6 +77,7 @@ module "active_directory_dns_resolver" {
 
   vpc               = module.networking.vpc
   ad_dns_server_ips = module.active_directory.dns_servers
+  dns_search        = module.networking.private_dns.base_domain
 }
 
 module "marklogic" {
@@ -86,6 +88,7 @@ module "marklogic" {
   vpc             = module.networking.vpc
   private_subnets = module.networking.ml_private_subnets
   instance_type   = "r5.xlarge"
+  private_dns     = module.networking.private_dns
 }
 
 module "gh_runner" {
@@ -96,6 +99,7 @@ module "gh_runner" {
   vpc               = module.networking.vpc
   github_token      = var.github_actions_runner_token
   ssh_ingress_sg_id = module.bastion.bastion_security_group_id
+  private_dns       = module.networking.private_dns
 }
 
 resource "tls_private_key" "jaspersoft_ssh_key" {
@@ -118,4 +122,5 @@ module "jaspersoft" {
   allow_ssh_from_sg_id          = module.bastion.bastion_security_group_id
   jaspersoft_binaries_s3_bucket = var.jasper_s3_bucket
   enable_backup                 = false
+  private_dns                   = module.networking.private_dns
 }

--- a/terraform/test/main.tf
+++ b/terraform/test/main.tf
@@ -94,6 +94,7 @@ module "active_directory_dns_resolver" {
 
   vpc               = module.networking.vpc
   ad_dns_server_ips = module.active_directory.dns_servers
+  dns_search        = module.networking.private_dns.base_domain
 }
 
 resource "tls_private_key" "jaspersoft_ssh_key" {

--- a/terraform/test/main.tf
+++ b/terraform/test/main.tf
@@ -86,6 +86,7 @@ module "active_directory" {
   ldaps_ca_subnet              = module.networking.ldaps_ca_subnet
   environment                  = "test"
   rdp_ingress_sg_id            = module.bastion.bastion_security_group_id
+  private_dns                  = module.networking.private_dns
 }
 
 module "active_directory_dns_resolver" {
@@ -115,6 +116,7 @@ module "jaspersoft" {
   allow_ssh_from_sg_id          = module.bastion.bastion_security_group_id
   jaspersoft_binaries_s3_bucket = var.jasper_s3_bucket
   enable_backup                 = true
+  private_dns                   = module.networking.private_dns
 }
 
 locals {


### PR DESCRIPTION
This lets us simplify the roxy job since the MarkLogic NLB is now always at `marklogic.vpc.local`.