### PR TITLE
DT-66: LDAP for Jasper Reports server

### DIFF
--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Clone repo
         uses: actions/checkout@master
       - name: tfsec
-        uses: aquasecurity/tfsec-pr-commenter-action@v1.2.0
+        uses: aquasecurity/tfsec-pr-commenter-action@main
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           working_directory: terraform/

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ MarkLogic can't be configured without AD, so bring this up next.
 terraform apply -target module.active_directory
 ```
 
-Complete the manual setup steps in the module README, then configure the VPC DHCP to use the AD DNS servers.
+Complete the manual setup steps in the module README, then configure the VPC DHCP to use the AD DNS servers by running:
 
 ```sh
 terraform apply -target module.active_directory_dns_resolver
@@ -172,7 +172,7 @@ Now run the MarkLogic setup jobs from GitHub.
 
 ### 6 JasperReports server
 
-Ensure the Jasper binaries S3 bucket exists and has the expected JasperReports zip in, follow the instructions in the module readme to create the S3 bucket if not.
+Follow the setup instructions in the module readme.
 Make sure the `jasper_s3_bucket` variable is set correctly.
 
 ```sh

--- a/manual_scripts/active_directory/groups.csv
+++ b/manual_scripts/active_directory/groups.csv
@@ -16,3 +16,5 @@ datamart-delta-data-certifiers
 datamart-delta-admin
 datamart-user
 datamart-cpm-soap-api
+jasperreports-users
+jasperreports-admins

--- a/manual_scripts/active_directory/users-to-groups.csv
+++ b/manual_scripts/active_directory/users-to-groups.csv
@@ -11,3 +11,6 @@ datamart-cpm-soap-api,sap
 datamart-delta-admin,sap
 datamart-delta-admin,cpmapp
 AWS Delegated Administrators,cpmapp
+jasperreports-admins,jasperadminuser
+jasperreports-users,jasperuser
+jasperreports-users,jasperreports-admins

--- a/manual_scripts/active_directory/users.csv
+++ b/manual_scripts/active_directory/users.csv
@@ -10,5 +10,5 @@ cpmapp,Password123,cpm.app@dluhcdata.local,CPM App,cpm.app,"OU=Users,OU=dluhcdat
 sap,Password123,sap@dluhcdata.local,SAP,sap,"OU=Users,OU=dluhcdata,DC=dluhcdata,DC=local"
 eclaims,Password123,eclaims@dluhcdata.local,Eclaims,eclaims,"OU=Users,OU=dluhcdata,DC=dluhcdata,DC=local"
 jasperreports,Password123,jasperreports@dluhcdata.local,Jasper Reports app,jasperreports,"OU=Users,OU=dluhcdata,DC=dluhcdata,DC=local"
-jasperuser,Password123,jasperuser@dluhcdata.local,Jasper User,jasperuser,"OU=Users,OU=dluhcdata,DC=dluhcdata,DC=local"
-jasperadminuser,Password123,jasperadminuser@dluhcdata.local,Jasper Admin User,jasperadminuser,"OU=Users,OU=dluhcdata,DC=dluhcdata,DC=local"
+jasperuser,Password123,jasperuser@dluhcdata.local,Jasper User,jasperuser,"CN=Datamart,OU=Users,OU=dluhcdata,DC=dluhcdata,DC=local"
+jasperadminuser,Password123,jasperadminuser@dluhcdata.local,Jasper Admin User,jasperadminuser,"CN=Datamart,OU=Users,OU=dluhcdata,DC=dluhcdata,DC=local"

--- a/manual_scripts/active_directory/users.csv
+++ b/manual_scripts/active_directory/users.csv
@@ -9,3 +9,6 @@ paymentapprover,Password123,payment.approver@dluhcdata.local,Payment Approver,pa
 cpmapp,Password123,cpm.app@dluhcdata.local,CPM App,cpm.app,"OU=Users,OU=dluhcdata,DC=dluhcdata,DC=local"
 sap,Password123,sap@dluhcdata.local,SAP,sap,"OU=Users,OU=dluhcdata,DC=dluhcdata,DC=local"
 eclaims,Password123,eclaims@dluhcdata.local,Eclaims,eclaims,"OU=Users,OU=dluhcdata,DC=dluhcdata,DC=local"
+jasperreports,Password123,jasperreports@dluhcdata.local,Jasper Reports app,jasperreports,"OU=Users,OU=dluhcdata,DC=dluhcdata,DC=local"
+jasperuser,Password123,jasperuser@dluhcdata.local,Jasper User,jasperuser,"OU=Users,OU=dluhcdata,DC=dluhcdata,DC=local"
+jasperadminuser,Password123,jasperadminuser@dluhcdata.local,Jasper Admin User,jasperadminuser,"OU=Users,OU=dluhcdata,DC=dluhcdata,DC=local"

--- a/terraform/modules/jaspersoft/README.md
+++ b/terraform/modules/jaspersoft/README.md
@@ -1,5 +1,7 @@
 # JasperReports Server
 
+The password for the "jasperreports" ldap user must be in a secret named `jasperserver-ldap-bind-password-${var.environment}` using the AWS managed KMS key.
+
 Requires S3 bucket (var.jaspersoft_binaries_s3_bucket) in the current AWS account with JasperReports Server binaries in.
 
 ```sh
@@ -7,7 +9,7 @@ aws s3api create-bucket --bucket dluhc-jaspersoft-bin --acl private --region eu-
 aws s3api put-bucket-versioning --bucket dluhc-jaspersoft-bin --versioning-configuration Status=Enabled
 ```
 
-We've combined Jasper Reports Community edition 7.8.0, the 7.8.1 Service Pack and 2022-04-15 cumulative hotfix into one zip:
+We've combined Jasper Reports Community edition 7.8.0, the 7.8.1 Service Pack, the 2022-04-15 cumulative hotfix and web services plugin into one zip:
 
 ```sh
 #!/bin/bash -ex
@@ -15,6 +17,7 @@ We've combined Jasper Reports Community edition 7.8.0, the 7.8.1 Service Pack an
 unzip -q TIB_js-jrs-cp_7.8.0_bin.zip
 unzip -q TIB_js-jrs_cp_7.8.1_sp.zip -d js-sp-7.8.1
 unzip -q hotfix_jrspro7.8.1_cumulative_20220415_1823.zip -d js-hotfix-7.8.1
+unzip -q jaspersoft_webserviceds_v1.5.zip -d webservices
 # Update postgres driver
 rm jasperreports-server-cp-7.8.0-bin/buildomatic/conf_source/db/postgresql/jdbc/postgresql-42.2.5.jar
 wget -O jasperreports-server-cp-7.8.0-bin/buildomatic/conf_source/db/postgresql/jdbc/postgresql-42.5.0.jar "https://jdbc.postgresql.org/download/postgresql-42.5.0.jar"
@@ -49,6 +52,10 @@ cd ../../jasperreports-server-cp-7.8.0-bin/jasperserver/WEB-INF/lib
 rm log4j-1.2-api-2.13.3.jar log4j-api-2.13.3.jar log4j-core-2.13.3.jar log4j-jcl-2.13.3.jar log4j-jul-2.13.3.jar log4j-slf4j-impl-2.13.3.jar log4j-web-2.13.3.jar
 cd ../../../..
 rsync -a war-hotfix/WEB-INF/ jasperreports-server-cp-7.8.0-bin/jasperserver/WEB-INF/
+
+## Web services plugin
+sed -i 's/queryLanguagesPro/queryLanguagesCe/' webservices/JRS/WEB-INF/applicationContext-WebServiceDataSource.xml
+cp -r webservices/JRS/WEB-INF/* jasperreports-server-cp-7.8.0-bin/jasperserver/WEB-INF/
 
 ## Recreate WAR
 rm jasperreports-server-cp-7.8.0-bin/jasperserver.war

--- a/terraform/modules/jaspersoft/alb.tf
+++ b/terraform/modules/jaspersoft/alb.tf
@@ -131,6 +131,11 @@ resource "aws_lb_target_group" "main" {
   target_type = "instance"
   vpc_id      = var.vpc_id
 
+  health_check {
+    path                = "/jasperserver/rest_v2/serverInfo"
+    unhealthy_threshold = 5
+  }
+
   lifecycle {
     create_before_destroy = true
   }

--- a/terraform/modules/jaspersoft/install_files/applicationContext-externalAuth-LDAP.xml
+++ b/terraform/modules/jaspersoft/install_files/applicationContext-externalAuth-LDAP.xml
@@ -1,0 +1,213 @@
+<!--
+  ~ Copyright (C) 2005 - 2020 TIBCO Software Inc. All rights reserved.
+  ~ http://www.jaspersoft.com.
+  ~
+  ~ Unless you have purchased a commercial license agreement from Jaspersoft,
+  ~ the following license terms apply:
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as
+  ~ published by the Free Software Foundation, either version 3 of the
+  ~ License, or (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with this program. If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd">
+
+    <!-- ############ LDAP authentication ############
+      - Sample configuration of external authentication via an external LDAP server.
+    -->
+
+    <bean id="proxyAuthenticationProcessingFilter" class="com.jaspersoft.jasperserver.api.security.EncryptionAuthenticationProcessingFilter"
+        parent="authenticationProcessingFilter">
+        <property name="authenticationManager">
+            <ref bean="ldapAuthenticationManager" />
+        </property>
+        <property name="authenticationSuccessHandler" ref="externalAuthSuccessHandler" />
+    </bean>
+
+    <bean id="proxyAuthenticationRestProcessingFilter" class="com.jaspersoft.jasperserver.api.security.externalAuth.DefaultAuthenticationRestProcessingFilter">
+        <property name="authenticationManager">
+            <ref bean="ldapAuthenticationManager" />
+        </property>
+        <property name="authenticationFailureHandler">
+            <bean class="com.jaspersoft.jasperserver.api.security.externalAuth.RestAuthenticationFailureHandler" />
+        </property>
+        <property name="authenticationSuccessHandler">
+            <bean class="com.jaspersoft.jasperserver.api.security.externalAuth.RestAuthenticationSuccessHandler">
+                <property name="externalDataSynchronizer" ref="externalDataSynchronizer" />
+            </bean>
+        </property>
+
+        <property name="rememberMeServices">
+            <bean class="org.springframework.security.web.authentication.NullRememberMeServices" />
+        </property>
+
+        <property name="filterProcessesUrl" value="/rest_v2/login" />
+    </bean>
+
+    <bean id="proxyRequestParameterAuthenticationFilter"
+        class="com.jaspersoft.jasperserver.war.util.ExternalRequestParameterAuthenticationFilter" parent="requestParameterAuthenticationFilter">
+        <property name="authenticationManager">
+            <ref bean="ldapAuthenticationManager" />
+        </property>
+        <property name="externalDataSynchronizer" ref="externalDataSynchronizer" />
+    </bean>
+
+    <bean id="proxyRestRequestParameterAuthenticationFilter"
+        class="com.jaspersoft.jasperserver.war.util.ExternalRequestParameterAuthenticationFilter" parent="restRequestParameterAuthenticationFilter">
+        <property name="authenticationManager">
+            <ref bean="ldapAuthenticationManager" />
+        </property>
+        <property name="externalDataSynchronizer" ref="externalDataSynchronizer" />
+    </bean>
+
+    <bean id="externalAuthSuccessHandler"
+        class="com.jaspersoft.jasperserver.api.security.externalAuth.JrsExternalAuthenticationSuccessHandler" parent="successHandler">
+        <property name="externalDataSynchronizer">
+            <ref bean="externalDataSynchronizer" />
+        </property>
+    </bean>
+
+    <bean id="proxyBasicProcessingFilter"
+        class="com.jaspersoft.jasperserver.api.security.externalAuth.ExternalAuthBasicProcessingFilter" parent="basicProcessingFilter">
+        <!-- <property name="authenticationManager" ref="ldapAuthenticationManager" /> -->
+        <constructor-arg index="0"><ref bean="ldapAuthenticationManager"/></constructor-arg>
+        <property name="externalDataSynchronizer" ref="externalDataSynchronizer" />
+    </bean>
+
+    <bean id="ldapAuthenticationManager" class="com.jaspersoft.jasperserver.api.security.externalAuth.wrappers.spring.JSProviderManager">
+        <constructor-arg index="0">
+            <list>
+                <ref bean="ldapAuthenticationProvider" />
+                <ref bean="$${bean.daoAuthenticationProvider}" />
+                <!--anonymousAuthenticationProvider only needed if filterInvocationInterceptor.alwaysReauthenticate is set to true
+                <ref bean="anonymousAuthenticationProvider"/>-->
+            </list>
+        </constructor-arg>
+    </bean>
+
+    <bean id="ldapAuthenticationProvider" class="com.jaspersoft.jasperserver.api.security.externalAuth.wrappers.spring.ldap.JSLdapAuthenticationProvider">
+        <constructor-arg>
+            <bean class="com.jaspersoft.jasperserver.api.security.externalAuth.wrappers.spring.ldap.JSBindAuthenticator">
+                <constructor-arg>
+                    <ref bean="ldapContextSource" />
+                </constructor-arg>
+                <property name="userSearch" ref="userSearch" />
+            </bean>
+        </constructor-arg>
+        <constructor-arg>
+            <bean class="com.jaspersoft.jasperserver.api.security.externalAuth.wrappers.spring.ldap.JSDefaultLdapAuthoritiesPopulator">
+                <constructor-arg index="0">
+                    <ref bean="ldapContextSource" />
+                </constructor-arg>
+                <constructor-arg index="1">
+                    <value>ou=groups,ou=${AD_DOMAIN}</value>
+                </constructor-arg>
+                <property name="groupRoleAttribute" value="cn" />
+                <!-- Magic number means include transitive members -->
+                <property name="groupSearchFilter" value="(&amp;(objectClass=group)(member:1.2.840.113556.1.4.1941:={0}))" />
+
+                <property name="searchSubtree" value="true" />
+                <!-- Can setup additional external default roles here  <property name="defaultRole" value="LDAP"/> -->
+            </bean>
+        </constructor-arg>
+    </bean>
+
+    <bean id="userSearch"
+        class="com.jaspersoft.jasperserver.api.security.externalAuth.wrappers.spring.ldap.JSFilterBasedLdapUserSearch">
+        <constructor-arg index="0">
+            <value>ou=users,ou=${AD_DOMAIN}</value>
+        </constructor-arg>
+        <constructor-arg index="1">
+            <value>(&amp;(cn={0})(objectclass=user))</value>
+        </constructor-arg>
+        <constructor-arg index="2">
+            <ref bean="ldapContextSource" />
+        </constructor-arg>
+        <property name="searchSubtree">
+            <value>true</value>
+        </property>
+    </bean>
+
+
+    <bean id="ldapContextSource" class="com.jaspersoft.jasperserver.api.security.externalAuth.ldap.JSLdapContextSource">
+        <constructor-arg value="ldap://${AD_DOMAIN}.local:389/dc=${AD_DOMAIN},dc=local" />
+        <!-- manager user name and password (may not be needed)  -->
+        <property name="userDn" value="CN=jasperreports,OU=Users,OU=${AD_DOMAIN},DC=${AD_DOMAIN},DC=local" />
+        <property name="password" value="JASPERSOFT_BIND_USER_PASSWORD" />
+        <property name="referral" value="follow" />
+    </bean>
+
+    <!-- ############ LDAP authentication ############ -->
+
+    <!-- ############ JRS Synchronizer ############ -->
+    <bean id="externalDataSynchronizer"
+        class="com.jaspersoft.jasperserver.api.security.externalAuth.ExternalDataSynchronizerImpl">
+        <property name="externalUserProcessors">
+            <list>
+                <ref bean="externalUserSetupProcessor" />
+                <!-- Example processor for creating user folder-->
+                <!--<ref bean="externalUserFolderProcessor"/>-->
+            </list>
+        </property>
+    </bean>
+
+    <bean id="abstractExternalProcessor" class="com.jaspersoft.jasperserver.api.security.externalAuth.processors.AbstractExternalUserProcessor" abstract="true">
+        <property name="repositoryService" ref="$${bean.repositoryService}" />
+        <property name="userAuthorityService" ref="$${bean.userAuthorityService}" />
+        <property name="tenantService" ref="$${bean.tenantService}" />
+        <property name="profileAttributeService" ref="profileAttributeService" />
+        <property name="objectPermissionService" ref="objectPermissionService" />
+    </bean>
+
+    <bean id="externalUserSetupProcessor" class="com.jaspersoft.jasperserver.api.security.externalAuth.processors.ExternalUserSetupProcessor" parent="abstractExternalProcessor">
+        <!--Default permitted role characters; others are removed. Change regular expression to allow other chars.
+                    <property name="permittedExternalRoleNameRegex" value="[A-Za-z0-9_]+"/>-->
+
+        <property name="userAuthorityService">
+            <ref bean="$${bean.internalUserAuthorityService}" />
+        </property>
+        <property name="defaultInternalRoles">
+            <list>
+                <!-- No default permissions, users must be in the jasperreports-users group -->
+                <!-- <value>ROLE_USER</value> -->
+            </list>
+        </property>
+
+        <property name="organizationRoleMap">
+            <map>
+                <entry>
+                    <key>
+                        <value>ROLE_JASPERREPORTS-USERS</value>
+                    </key>
+                    <value>ROLE_USER</value>
+                </entry>
+                <entry>
+                    <key>
+                        <value>ROLE_JASPERREPORTS-ADMINS</value>
+                    </key>
+                    <value>ROLE_ADMINISTRATOR</value>
+                </entry>
+            </map>
+        </property>
+    </bean>
+
+    <!-- EXAMPLE Processor
+    <bean id="externalUserFolderProcessor"
+          class="com.jaspersoft.jasperserver.api.security.externalAuth.processors.ExternalUserFolderProcessor"
+          parent="abstractExternalProcessor">
+        <property name="repositoryService" ref="$${bean.unsecureRepositoryService}"/>
+    </bean>
+    -->
+    <!-- ############ JRS Synchronizer ############ -->
+</beans>

--- a/terraform/modules/jaspersoft/install_files/applicationContext-externalAuth-LDAP.xml
+++ b/terraform/modules/jaspersoft/install_files/applicationContext-externalAuth-LDAP.xml
@@ -126,7 +126,7 @@
     <bean id="userSearch"
         class="com.jaspersoft.jasperserver.api.security.externalAuth.wrappers.spring.ldap.JSFilterBasedLdapUserSearch">
         <constructor-arg index="0">
-            <value>ou=users,ou=${AD_DOMAIN}</value>
+            <value>cn=datamart,ou=users,ou=${AD_DOMAIN}</value>
         </constructor-arg>
         <constructor-arg index="1">
             <value>(&amp;(cn={0})(objectclass=user))</value>

--- a/terraform/modules/jaspersoft/instance_profile.tf
+++ b/terraform/modules/jaspersoft/instance_profile.tf
@@ -1,0 +1,62 @@
+resource "aws_iam_instance_profile" "jasperserver" {
+  name = "${var.prefix}jaspersoft-server-profile"
+  role = aws_iam_role.jasperserver.name
+}
+
+resource "aws_iam_role" "jasperserver" {
+  name = "${var.prefix}jaspersoft-server-role"
+  path = "/"
+
+  assume_role_policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Action": "sts:AssumeRole",
+            "Principal": {
+               "Service": "ec2.amazonaws.com"
+            },
+            "Effect": "Allow",
+            "Sid": ""
+        }
+    ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "read_jaspersoft_ldap_password" {
+  name = "${var.prefix}read-jaspersoft-ldap-password"
+  role = aws_iam_role.jasperserver.id
+
+  policy = data.aws_iam_policy_document.read_jaspersoft_ldap_password.json
+}
+
+data "aws_iam_policy_document" "read_jaspersoft_ldap_password" {
+  statement {
+    actions   = ["secretsmanager:GetSecretValue", "secretsmanager:DescribeSecret"]
+    effect    = "Allow"
+    resources = [data.aws_secretsmanager_secret.ldap_bind_password.arn]
+  }
+}
+
+# Allowing access to a single bucket seems reasonable
+# tfsec:ignore:aws-iam-no-policy-wildcards
+resource "aws_iam_role_policy" "read_jaspersoft_binaries" {
+  name = "${var.prefix}read-jaspersoft-binaries"
+  role = aws_iam_role.jasperserver.id
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "s3:GetObject"
+      ],
+      "Effect": "Allow",
+      "Resource": "${data.aws_s3_bucket.jaspersoft_binaries.arn}/*"
+    }
+  ]
+}
+EOF
+}

--- a/terraform/modules/jaspersoft/jaspersoft_install_bucket.tf
+++ b/terraform/modules/jaspersoft/jaspersoft_install_bucket.tf
@@ -7,86 +7,48 @@ data "aws_s3_object" "jaspersoft_install_zip" {
   key    = "js-7.8.1_hotfixed_2022-04-15.zip"
 }
 
-resource "aws_iam_instance_profile" "read_jaspersoft_binaries" {
-  name = "${var.prefix}jaspersoft-s3-access"
-  role = aws_iam_role.read_jaspersoft_binaries.name
-}
-
-resource "aws_iam_role" "read_jaspersoft_binaries" {
-  name = "${var.prefix}jaspersoft-s3-access"
-  path = "/"
-
-  assume_role_policy = <<EOF
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Action": "sts:AssumeRole",
-            "Principal": {
-               "Service": "ec2.amazonaws.com"
-            },
-            "Effect": "Allow",
-            "Sid": ""
-        }
-    ]
-}
-EOF
-}
-
-# Allowing access to a single bucket seems reasonable
-# tfsec:ignore:aws-iam-no-policy-wildcards
-resource "aws_iam_role_policy" "read_jaspersoft_binaries" {
-  name = "${var.prefix}read-jaspersoft-binaries"
-  role = aws_iam_role.read_jaspersoft_binaries.id
-
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": [
-        "s3:GetObject"
-      ],
-      "Effect": "Allow",
-      "Resource": "${data.aws_s3_bucket.jaspersoft_binaries.arn}/*"
-    }
-  ]
-}
-EOF
-}
-
 locals {
   tomcat_systemd_service_file_templated = templatefile("${path.module}/install_files/tomcat.service", { JAVA_OPTS_MAX_HEAP = var.java_max_heap })
 }
 
 resource "aws_s3_object" "tomcat_systemd_service_file" {
   bucket  = data.aws_s3_bucket.jaspersoft_binaries.bucket
-  key     = "tomcat.service"
+  key     = "${var.environment}/tomcat.service"
   content = local.tomcat_systemd_service_file_templated
   etag    = md5(local.tomcat_systemd_service_file_templated)
-  tags    = { environment = "shared" }
 }
 
 resource "aws_s3_object" "jaspersoft_config_file" {
   bucket = data.aws_s3_bucket.jaspersoft_binaries.bucket
-  key    = "default_master.properties"
+  key    = "${var.environment}/default_master.properties"
   source = "${path.module}/install_files/default_master.properties"
   etag   = filemd5("${path.module}/install_files/default_master.properties")
-  tags   = { environment = "shared" }
 }
 
 resource "aws_s3_object" "jaspersoft_root_index_jsp" {
   bucket = data.aws_s3_bucket.jaspersoft_binaries.bucket
-  key    = "root_index.jsp"
+  key    = "${var.environment}/root_index.jsp"
   source = "${path.module}/install_files/root_index.jsp"
   etag   = filemd5("${path.module}/install_files/root_index.jsp")
-  tags   = { environment = "shared" }
 }
 
 resource "aws_s3_object" "jaspersoft_root_web_xml" {
   bucket = data.aws_s3_bucket.jaspersoft_binaries.bucket
-  key    = "root_web.xml"
+  key    = "${var.environment}/root_web.xml"
   source = "${path.module}/install_files/root_web.xml"
   etag   = filemd5("${path.module}/install_files/root_web.xml")
-  tags   = { environment = "shared" }
+}
+
+locals {
+  ldap_config_file_templated = templatefile(
+    "${path.module}/install_files/applicationContext-externalAuth-LDAP.xml",
+    { AD_DOMAIN = var.ad_domain }
+  )
+}
+
+resource "aws_s3_object" "jaspersoft_ldap_config" {
+  bucket  = data.aws_s3_bucket.jaspersoft_binaries.bucket
+  key     = "${var.environment}/applicationContext-externalAuth-LDAP.xml"
+  content = local.ldap_config_file_templated
+  etag    = md5(local.ldap_config_file_templated)
 }

--- a/terraform/modules/jaspersoft/variables.tf
+++ b/terraform/modules/jaspersoft/variables.tf
@@ -3,6 +3,10 @@ variable "prefix" {
   type        = string
 }
 
+variable "environment" {
+  type = string
+}
+
 variable "vpc_id" {
   type = string
 }
@@ -54,4 +58,8 @@ variable "private_dns" {
     zone_id     = string
     base_domain = string
   })
+}
+
+variable "ad_domain" {
+  default = "dluhcdata"
 }

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -125,4 +125,5 @@ module "jaspersoft" {
   jaspersoft_binaries_s3_bucket = var.jasper_s3_bucket
   enable_backup                 = false
   private_dns                   = module.networking.private_dns
+  environment                   = "staging"
 }

--- a/terraform/test/main.tf
+++ b/terraform/test/main.tf
@@ -143,6 +143,8 @@ module "jaspersoft" {
   jaspersoft_binaries_s3_bucket = var.jasper_s3_bucket
   enable_backup                 = true
   private_dns                   = module.networking.private_dns
+  ad_domain                     = "dluhctest"
+  environment                   = "test"
 }
 
 locals {


### PR DESCRIPTION
Differences from DataMart's staging setup:

* A new LDAP user (`jasperreports`) used for user and group lookups, rather than `superuser`
* Group membership lookup is transitive
* Membership of the `jasperreports-users` group is required to have any permissions, rather than all users having standard "ROLE_USER" permissions
* Admin permissions are granted only to a new group, `jasperreports-admins`, rather than to members of `datamart-delta-admin` (we could add that group to `jasperreports-admins` group if we want)

I've also added the web services plugin mentioned in Confluence [here](https://digital.dclg.gov.uk/confluence/display/DEL/Jaspersoft+Server+Upgrade), though haven't tried to use it, and fixed the health check endpoint for the ALB.

Note that user lookups are done by `cn`, not `sAMAccountName` as one might expect when using Active Directory. In DataMart as far as I can tell for most users:
* `uid` is not set
* `sAMAccountName` is a generated effectively random string
* `cn` is the user's email address with `@` replaced by `!`

So users will need to log in as e.g. `john.smith!example.com`.