### PR TITLE
DT-35: draft commonising ecr code in common-infra

### DIFF
--- a/terraform/modules/ecr_repository/ecr_lifecycle_policy.json
+++ b/terraform/modules/ecr_repository/ecr_lifecycle_policy.json
@@ -1,0 +1,27 @@
+{
+  "rules": [{
+    "rulePriority": 1,
+    "description": "Only keep 20 most recent snapshot images",
+    "selection": {
+      "tagStatus": "tagged",
+      "tagPrefixList": ["snapshot-"],
+      "countType": "imageCountMoreThan",
+      "countNumber": 20
+    },
+    "action": {
+      "type": "expire"
+    }
+  },{
+    "rulePriority": 2,
+    "description": "Only keep 20 most recent release images",
+    "selection": {
+      "tagStatus": "tagged",
+      "tagPrefixList": ["release-"],
+      "countType": "imageCountMoreThan",
+      "countNumber": 20
+    },
+    "action": {
+      "type": "expire"
+    }
+  }]
+}

--- a/terraform/modules/ecr_repository/main.tf
+++ b/terraform/modules/ecr_repository/main.tf
@@ -1,0 +1,82 @@
+resource "aws_kms_key" "ecr_kms" {
+  enable_key_rotation = true
+}
+
+resource "aws_ecr_repository" "main" {
+  name                 = var.repo_name
+  image_tag_mutability = "IMMUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  encryption_configuration {
+    encryption_type = "KMS"
+    kms_key         = aws_kms_key.ecr_kms.arn
+  }
+}
+
+resource "aws_ecr_lifecycle_policy" "main" {
+  repository = aws_ecr_repository.main.name
+
+  policy = file("${path.module}/ecr_lifecycle_policy.json")
+}
+
+
+resource "aws_iam_user_policy" "main" {
+  name = "push-access-to-ecr-for-${var.repo_name}"
+  user = var.push_user
+
+  policy = jsonencode(
+    {
+      Version = "2012-10-17"
+      Statement = [
+        {
+          Effect = "Allow"
+          Action = [
+            "ecr:CompleteLayerUpload",
+            "ecr:UploadLayerPart",
+            "ecr:DescribeImages",
+            "ecr:InitiateLayerUpload",
+            "ecr:BatchCheckLayerAvailability",
+            "ecr:PutImage"
+          ]
+          Resource = [
+            aws_ecr_repository.main.arn
+          ]
+          Sid = "1"
+        },
+        {
+          Effect   = "Allow"
+          Action   = ["ecr:GetAuthorizationToken"]
+          Resource = "*"
+          Sid      = "2"
+        }
+      ]
+    }
+  )
+}
+
+resource "aws_ecr_repository_policy" "read" {
+  repository = aws_ecr_repository.main.name
+
+  policy = jsonencode(
+    {
+      "Version" : "2012-10-17",
+      "Statement" : [
+        {
+          "Sid" : "AllowPullFromDevAccount",
+          "Effect" : "Allow",
+          "Principal" : {
+            "AWS" : "arn:aws:iam::${var.dev_aws_account_id}:root"
+          },
+          "Action" : [
+            "ecr:BatchCheckLayerAvailability",
+            "ecr:GetDownloadUrlForLayer",
+            "ecr:BatchGetImage",
+          ]
+        }
+      ]
+    }
+  )
+}

--- a/terraform/modules/ecr_repository/variables.tf
+++ b/terraform/modules/ecr_repository/variables.tf
@@ -1,0 +1,10 @@
+variable "repo_name" {
+}
+
+variable "dev_aws_account_id" {
+  default = "486283582667"
+}
+
+variable "push_user" {
+  description = "IAM user who should have push permissions"
+}

--- a/terraform/production/ecr.tf
+++ b/terraform/production/ecr.tf
@@ -1,0 +1,41 @@
+# tfsec:ignore:aws-iam-no-user-attached-policies
+resource "aws_iam_user" "cpm_ci" {
+  name = "cpm-ci"
+}
+
+# tfsec:ignore:aws-iam-no-user-attached-policies
+resource "aws_iam_user" "delta_ci" {
+  name = "delta_ci"
+}
+
+resource "aws_iam_access_key" "cpm_ci" {
+  user = aws_iam_user.cpm_ci.name
+}
+
+resource "aws_iam_access_key" "delta_ci" {
+  user = aws_iam_user.delta_ci.name
+}
+
+locals {
+  repositories = [{
+    repo_name = "cpm",
+    push_user = aws_iam_user.cpm_ci.name
+    }, {
+    repo_name = "delta_api",
+    push_user = aws_iam_user.delta_ci.name
+    }, {
+    repo_name = "delta_internal",
+    push_user = aws_iam_user.delta_ci.name
+    }, {
+    repo_name = "delta_fo_to_pdf",
+    push_user = aws_iam_user.delta_ci.name
+  }]
+}
+
+module "ecr" {
+  count  = length(local.repositories)
+  source = "../modules/ecr_repository"
+
+  repo_name = local.repositories[count.index]["repo_name"]
+  push_user = local.repositories[count.index]["push_user"]
+}

--- a/terraform/production/ecr.tf
+++ b/terraform/production/ecr.tf
@@ -17,25 +17,30 @@ resource "aws_iam_access_key" "delta_ci" {
 }
 
 locals {
-  repositories = [{
-    repo_name = "cpm",
-    push_user = aws_iam_user.cpm_ci.name
-    }, {
-    repo_name = "delta_api",
-    push_user = aws_iam_user.delta_ci.name
-    }, {
-    repo_name = "delta_internal",
-    push_user = aws_iam_user.delta_ci.name
-    }, {
-    repo_name = "delta_fo_to_pdf",
-    push_user = aws_iam_user.delta_ci.name
-  }]
+  repositories = {
+    "cpm" = {
+      repo_name = "cpm",
+      push_user = aws_iam_user.cpm_ci.name
+    },
+    "delta_api" = {
+      repo_name = "delta_api",
+      push_user = aws_iam_user.delta_ci.name
+    },
+    "delta_internal" = {
+      repo_name = "delta_internal",
+      push_user = aws_iam_user.delta_ci.name
+    },
+    "delta_fo_to_pdf" = {
+      repo_name = "delta_fo_to_pdf",
+      push_user = aws_iam_user.delta_ci.name
+    }
+  }
 }
 
 module "ecr" {
-  count  = length(local.repositories)
-  source = "../modules/ecr_repository"
+  for_each = local.repositories
+  source   = "../modules/ecr_repository"
 
-  repo_name = local.repositories[count.index]["repo_name"]
-  push_user = local.repositories[count.index]["push_user"]
+  repo_name = each.value["repo_name"]
+  push_user = each.value["push_user"]
 }

--- a/terraform/production/outputs.tf
+++ b/terraform/production/outputs.tf
@@ -26,3 +26,20 @@ output "codeartifact_domain_arn" {
   value = module.codeartifact.domain_arn
 }
 
+output "cpm_ci_access_key" {
+  value = aws_iam_access_key.cpm_ci.id
+}
+
+output "cpm_ci_secret_key" {
+  value     = aws_iam_access_key.cpm_ci.secret
+  sensitive = true
+}
+
+output "delta_ci_access_key" {
+  value = aws_iam_access_key.cpm_ci.id
+}
+
+output "delta_ci_secret_key" {
+  value     = aws_iam_access_key.cpm_ci.secret
+  sensitive = true
+}


### PR DESCRIPTION
@BenRamchandani This what you envisioned?

Yes it commonises code, but downsides are:
* the lifecycle policy is coupled to a workflow in a different repo
* this repo is big enough already. This is a small addition but it all adds up.

Only worth it if you think we're more likely to want to apply changes to both delta/CPM than to iterate on the two repos separately. It's a small block of code and could go either place. If merging this, we just need to remove the existing resources from the other state and import them here