### PR TITLE
DT-170: Restrict SES user to VPC

### DIFF
--- a/terraform/modules/ses_user/main.tf
+++ b/terraform/modules/ses_user/main.tf
@@ -1,3 +1,7 @@
+variable "vpc_id" {
+  type = string
+}
+
 variable "username" {
   type = string
 }
@@ -37,6 +41,11 @@ data "aws_iam_policy_document" "ses_sender" {
       test     = "StringLike"
       variable = "ses:FromAddress"
       values   = [var.from_address_pattern]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceVpc"
+      values   = [var.vpc_id]
     }
   }
 }

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -254,6 +254,7 @@ module "delta_ses_user" {
   from_address_pattern = "delta-staging@datacollection.test.levellingup.gov.uk"
   environment          = "staging"
   kms_key_arn          = module.marklogic.deploy_user_kms_key_arn
+  vpc_id               = module.networking.vpc.id
 }
 
 module "cpm_ses_user" {
@@ -263,4 +264,5 @@ module "cpm_ses_user" {
   from_address_pattern = "cpm-staging@datacollection.test.levellingup.gov.uk"
   environment          = "staging"
   kms_key_arn          = module.marklogic.deploy_user_kms_key_arn
+  vpc_id               = module.networking.vpc.id
 }


### PR DESCRIPTION
I haven't tried applying/testing this as I know you're doing email stuff at the moment. I'm not sure whether it will work, the docs don't specify what actions you can use the sourceVpc condition on.