### PR TITLE
DT-162: Create SSM Maintenance window for MarkLogic yum patching

### DIFF
--- a/terraform/modules/marklogic/marklogic_iam.tf
+++ b/terraform/modules/marklogic/marklogic_iam.tf
@@ -157,3 +157,33 @@ data "aws_iam_policy_document" "ml_s3_backups" {
     resources = [aws_kms_key.ml_backup_bucket_key.arn]
   }
 }
+
+resource "aws_iam_role_policy_attachment" "ml_cloudwatch" {
+  role       = aws_iam_role.ml_iam_role.name
+  policy_arn = aws_iam_policy.ml_cloudwatch.arn
+}
+
+resource "aws_iam_policy" "ml_cloudwatch" {
+  name        = "ml-instance-logs-${var.environment}"
+  description = "Allows MarkLogic instances to write logs to CloudWatch"
+
+  policy = data.aws_iam_policy_document.ml_cloudwatch.json
+}
+
+# tfsec:ignore:aws-iam-no-policy-wildcards
+data "aws_iam_policy_document" "ml_cloudwatch" {
+
+  statement {
+    actions   = ["logs:DescribeLogGroups"]
+    resources = ["*"]
+  }
+
+  statement {
+    actions = [
+      "logs:CreateLogStream",
+      "logs:DescribeLogStreams",
+      "logs:PutLogEvents",
+    ]
+    resources = ["${aws_cloudwatch_log_group.ml_patch.arn}:*"]
+  }
+}

--- a/terraform/modules/marklogic/marklogic_stack.tf
+++ b/terraform/modules/marklogic/marklogic_stack.tf
@@ -9,8 +9,12 @@ data "aws_secretsmanager_secret_version" "ml_admin_user" {
   secret_id = "ml-admin-user-${var.environment}"
 }
 
+locals {
+  stack_name = "marklogic-stack-${var.environment}"
+}
+
 resource "aws_cloudformation_stack" "marklogic" {
-  name = "marklogic-stack-${var.environment}"
+  name = local.stack_name
 
   parameters = {
     IAMRole       = aws_iam_instance_profile.ml_instance_profile.name

--- a/terraform/modules/marklogic/patching.tf
+++ b/terraform/modules/marklogic/patching.tf
@@ -1,0 +1,113 @@
+resource "aws_ssm_maintenance_window" "ml_patch" {
+  name              = "marklogic-patch-${var.environment}"
+  schedule          = "cron(00 06 ? * ${var.patch_day} *)"
+  schedule_timezone = "Etc/UTC"
+  duration          = 2
+  cutoff            = 1
+}
+
+resource "aws_ssm_maintenance_window_target" "ml_servers" {
+  window_id     = aws_ssm_maintenance_window.ml_patch.id
+  name          = "marklogic-${var.environment}"
+  description   = "MarkLogic servers from the ${var.environment} environment"
+  resource_type = "INSTANCE"
+
+  targets {
+    key    = "tag:marklogic:stack:name"
+    values = [local.stack_name]
+  }
+}
+
+# Yum update output, non-sensitive
+# tfsec:ignore:aws-cloudwatch-log-group-customer-key
+resource "aws_cloudwatch_log_group" "ml_patch" {
+  name              = "${var.environment}/marklogic-ssm-patch"
+  retention_in_days = 60
+}
+
+resource "aws_ssm_maintenance_window_task" "ml_patch" {
+  name            = "marklogic-patch-${var.environment}"
+  window_id       = aws_ssm_maintenance_window.ml_patch.id
+  max_concurrency = 1
+  max_errors      = 0
+  priority        = 1
+  task_arn        = "AWS-RunShellScript"
+  task_type       = "RUN_COMMAND"
+  cutoff_behavior = "CONTINUE_TASK"
+
+  targets {
+    key    = "WindowTargetIds"
+    values = [aws_ssm_maintenance_window_target.ml_servers.id]
+  }
+
+  task_invocation_parameters {
+    run_command_parameters {
+      comment         = "Yum update security"
+      timeout_seconds = 900
+
+      service_role_arn = aws_iam_role.ml_patch_sns_publish.arn
+      notification_config {
+        notification_arn    = aws_sns_topic.ml_patch_notifications.arn
+        notification_events = ["TimedOut", "Cancelled", "Failed"]
+        notification_type   = "Command"
+      }
+
+      parameter {
+        name   = "commands"
+        values = ["yum update --security -y"]
+      }
+
+      cloudwatch_config {
+        cloudwatch_log_group_name = aws_cloudwatch_log_group.ml_patch.name
+        cloudwatch_output_enabled = true
+      }
+    }
+  }
+}
+
+# SNS topic for errors with the maintenance window job. Non-sensitive.
+# tfsec:ignore:aws-sns-enable-topic-encryption
+resource "aws_sns_topic" "ml_patch_notifications" {
+  name = "marklogic-patch-errors-${var.environment}"
+}
+
+# TODO DT-49: Add subscription
+
+resource "aws_iam_role" "ml_patch_sns_publish" {
+  name = "marklogic-patch-sns-publish-${var.environment}"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "ssm.amazonaws.com"
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "ml_patch_sns_publish" {
+  role       = aws_iam_role.ml_patch_sns_publish.name
+  policy_arn = aws_iam_policy.ml_patch_sns_publish.arn
+}
+
+resource "aws_iam_policy" "ml_patch_sns_publish" {
+  name        = "marklogic-patch-sns-publish-${var.environment}"
+  description = "Used by SSM to push notifications when MarkLogic os updates fail to apply"
+
+  policy = data.aws_iam_policy_document.ml_patch_sns_publish.json
+}
+
+data "aws_iam_policy_document" "ml_patch_sns_publish" {
+  statement {
+    actions = ["sns:Publish"]
+    effect  = "Allow"
+    resources = [
+      aws_sns_topic.ml_patch_notifications.arn
+    ]
+  }
+}

--- a/terraform/modules/marklogic/variables.tf
+++ b/terraform/modules/marklogic/variables.tf
@@ -36,3 +36,12 @@ variable "data_volume_size_gb" {
 variable "ebs_backup_error_notification_emails" {
   type = list(string)
 }
+
+variable "patch_day" {
+  type = string
+
+  validation {
+    condition     = contains(["MON", "TUE", "WED", "THU", "FRI", "SAT", "SUN"], var.patch_day)
+    error_message = "patch_day must be a day of the week"
+  }
+}

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -203,6 +203,7 @@ module "marklogic" {
   instance_type       = "r5.xlarge"
   private_dns         = module.networking.private_dns
   data_volume_size_gb = 200
+  patch_day           = "TUE"
 
   ebs_backup_error_notification_emails = ["Group-DLUHCDeltaNotifications+staging@softwire.com"]
 }

--- a/terraform/test/main.tf
+++ b/terraform/test/main.tf
@@ -215,6 +215,7 @@ module "marklogic" {
   private_subnets = module.networking.ml_private_subnets
   instance_type   = "t3.large"
   private_dns     = module.networking.private_dns
+  patch_day       = "MON"
 
   ebs_backup_error_notification_emails = ["Group-DLUHCDeltaNotifications+test@softwire.com"]
 }


### PR DESCRIPTION
Since we can't run a user data script.

Do you think it's worth pulling this out to cover the Jaspersoft and Delta servers as well? I'm pretty tempted to, it seems to work OK, and it's much easier to check on than cron.