### PR TITLE
DT-171: New proposed CI/CD flow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,10 +23,8 @@ jobs:
     with:
       workdir: terraform/test
       apply: true
-      environment: test
-    secrets:
-      access_key: ${{ secrets.access_key_dev }}
-      secret_key: ${{ secrets.secret_key_dev }}
+      apply_environment: test
+    secrets: inherit
   staging:
     name: Deploy to "Staging"
     needs: test
@@ -34,10 +32,8 @@ jobs:
     with:
       workdir: terraform/staging
       apply: true
-      environment: staging
-    secrets:
-      access_key: ${{ secrets.access_key_dev }}
-      secret_key: ${{ secrets.secret_key_dev }}
+      apply_environment: staging
+    secrets: inherit
   production:
     name: Deploy to "Production"
     needs: staging
@@ -45,7 +41,6 @@ jobs:
     with:
       workdir: terraform/production
       apply: true
-      environment: production
-    secrets:
-      access_key: ${{ secrets.access_key_prod }}
-      secret_key: ${{ secrets.secret_key_prod }}
+      plan_environment: production
+      apply_environment: production
+    secrets: inherit

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -15,33 +15,71 @@ jobs:
         uses: actions/checkout@v3
       - name: Check formatting of all Terraform files
         run: terraform fmt -check -diff -recursive
-  validate_test:
-    name: Validate test Terraform config
-    uses: ./.github/workflows/terraform.yml
-    with:
-      workdir: terraform/test
-    secrets:
-      access_key: "${{secrets.access_key_dev}}"
-      secret_key: "${{secrets.secret_key_dev}}"
-  validate_staging:
-    name: Validate staging Terraform config
-    uses: ./.github/workflows/terraform.yml
-    with:
-      workdir: terraform/staging
-    secrets:
-      access_key: "${{secrets.access_key_dev}}"
-      secret_key: "${{secrets.secret_key_dev}}"
+  plan_test:
+    name: Test Terraform plan
+    runs-on: ubuntu-latest
+    env:
+      AWS_REGION: "eu-west-1"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: 1.3.6
+      - name: Terraform init
+        run: terraform init -input=false
+        working-directory: terraform/test
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.access_key }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.secret_key }}
+      - name: Terraform validate
+        run: terraform validate
+        working-directory: terraform/test
+      - name: Terraform plan
+        run: terraform plan -no-color -input=false -refresh=false -lock=false
+        working-directory: terraform/test
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.access_key }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.secret_key }}
+  plan_staging:
+    name: Staging Terraform plan
+    runs-on: ubuntu-latest
+    env:
+      AWS_REGION: "eu-west-1"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: 1.3.6
+      - name: Terraform init
+        run: terraform init -input=false
+        working-directory: terraform/staging
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.access_key }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.secret_key }}
+      - name: Terraform validate
+        run: terraform validate
+        working-directory: terraform/staging
+      - name: Terraform plan
+        run: terraform plan -no-color -input=false -refresh=false -lock=false
+        working-directory: terraform/staging
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.access_key }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.secret_key }}
   validate_production:
     name: Validate production Terraform config
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3      
+        uses: actions/checkout@v3
       - name: Set up Terraform
         uses: hashicorp/setup-terraform@v2
         with:
-          terraform_version: 1.3.1
-      - name: Terraform Init
+          terraform_version: 1.3.6
+      - name: Terraform init
         run: terraform init -input=false -backend=false
         working-directory: terraform/production
       - name: Terraform validate

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -4,19 +4,18 @@ on:
   workflow_call:
     inputs:
       workdir:
-        required: false
+        required: true
         type: string
-        default: '.'
         description: directory to run Terraform commands from
-      apply:
+      plan_environment:
         required: false
-        type: boolean
-        default: false
-        description: whether to apply config, or otherwise just plan
-      environment:
-        required: false
+        default: ''
         type: string
-        description: If applying, specify a release "environment"
+        description: Environment to run the plan in
+      apply_environment:
+        required: true
+        type: string
+        description: Environment to run the apply in
     secrets:
       access_key:
         required: true
@@ -27,7 +26,7 @@ jobs:
   plan:
     name: Terraform plan
     runs-on: ubuntu-latest
-    environment: ${{ inputs.environment == 'production' && 'production' || '' }}
+    environment: ${{ inputs.plan_environment }}
     outputs:
       plan: ${{ steps.plan.outputs.stdout }}
       plan_exitcode: ${{ steps.plan.outputs.exitcode }}
@@ -35,22 +34,23 @@ jobs:
       run:
         working-directory: ${{ inputs.workdir }}
     env:
-      AWS_ACCESS_KEY_ID: ${{ secrets.access_key }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.secret_key }}
       AWS_REGION: "eu-west-1"
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      
+
       - name: Set up Terraform
         # Exposes stdout, stderr and exitcode as outputs for any steps that run terraform
         uses: hashicorp/setup-terraform@v2
         with:
-          terraform_version: 1.3.1
+          terraform_version: 1.3.6
 
-      - name: Terraform Init
+      - name: Terraform init
         id: init
         run: terraform init -input=false
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.access_key }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.secret_key }}
 
       - name: Terraform Plan
         id: plan
@@ -58,26 +58,27 @@ jobs:
         # Output a plan even though we don't use it here - we need the printed output to be the same as in the apply job below
         # We don't save the plan as an artefact as it's sensitive and this repo is public
         run: >
-          terraform plan -no-color -input=false -detailed-exitcode -lock=${{ inputs.apply && 'true' || 'false' }} -out=plan.tfplan | sed '/ Refreshing state... /d' | sed '/ Reading...$/d' | sed '/ Read complete after /d';
+          terraform plan -no-color -input=false -detailed-exitcode -out=plan.tfplan | sed '/ Refreshing state... /d' | sed '/ Reading...$/d' | sed '/ Read complete after /d';
           exit ${PIPESTATUS[0]}
         continue-on-error: true
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.access_key }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.secret_key }}
 
       - name: Fail job if plan failed
         if: steps.plan.outputs.exitcode == 1
         run: exit 1
-        
+
   apply:
     name: Terraform apply
     needs: plan
     runs-on: ubuntu-latest
-    environment: ${{ inputs.environment }}
-    if: inputs.apply && needs.plan.outputs.plan_exitcode == 2
+    environment: ${{ inputs.apply_environment }}
+    if: needs.plan.outputs.plan_exitcode == 2
     defaults:
       run:
         working-directory: ${{ inputs.workdir }}
     env:
-      AWS_ACCESS_KEY_ID: ${{ secrets.access_key }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.secret_key }}
       AWS_REGION: "eu-west-1"
     steps:
       - name: Checkout
@@ -86,15 +87,21 @@ jobs:
       - name: Set up Terraform
         uses: hashicorp/setup-terraform@v2
         with:
-          terraform_version: 1.3.1
+          terraform_version: 1.3.6
 
-      - name: Terraform Init
+      - name: Terraform init
         id: init
         run: terraform init -input=false
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.access_key }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.secret_key }}
 
       - name: Terraform Plan
         id: repeat_plan
         run: terraform plan -no-color -input=false -detailed-exitcode -out=plan.tfplan | sed '/ Refreshing state... /d' | sed '/ Reading...$/d' | sed '/ Read complete after /d'
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.access_key }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.secret_key }}
 
       - name: Compare plans
         if: steps.repeat_plan.outputs.stdout != needs.plan.outputs.plan
@@ -104,3 +111,6 @@ jobs:
 
       - name: Terraform Apply
         run: terraform apply -auto-approve -input=false plan.tfplan
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.access_key }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.secret_key }}


### PR DESCRIPTION
Plan is to make a CI user that has enough permissions to do a `terraform plan` on the dev account, and use that for pull requests.
I've started on the policy in #95, needs another couple of permissions.
It's still a high privilege user, but much less than admin.

Otherwise it should work the same as before, each environment will have an admin key, required for the production plan and all the applys.

I haven't really tested it, will have to merge it and see.

Also:

* Bumped terraform version to 1.3.6
* Moved the AWS secrets to only the specific steps that use them, which is mostly just me being paranoid, but there's no reason to pass them to `hashicorp/setup-terraform` or `checkout`
* The pull request workflow no longer uses the reusable terraform one, it's a bit more repetition, but I was getting confused
* Change all the secrets to be called `access_key` and `secret_key`, differences are controlled only by the environment.

When merging need to:

* Update required status checks
* Think about branch protection, possibly time to turn that on properly?