### PR TITLE
Ses policy

### DIFF
--- a/terraform/modules/networking/outputs.tf
+++ b/terraform/modules/networking/outputs.tf
@@ -76,3 +76,7 @@ output "private_dns" {
     base_domain = aws_route53_zone.private.name
   }
 }
+
+output "ses_vpce_id" {
+  value = aws_vpc_endpoint.ses_smtp.id
+}

--- a/terraform/modules/ses_user/main.tf
+++ b/terraform/modules/ses_user/main.tf
@@ -1,4 +1,4 @@
-variable "vpc_id" {
+variable "vpce_id" {
   type = string
 }
 
@@ -44,8 +44,8 @@ data "aws_iam_policy_document" "ses_sender" {
     }
     condition {
       test     = "StringEquals"
-      variable = "aws:SourceVpc"
-      values   = [var.vpc_id]
+      variable = "aws:SourceVpce"
+      values   = [var.vpce_id]
     }
   }
 }

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -273,7 +273,7 @@ module "delta_ses_user" {
   from_address_pattern = "delta-staging@datacollection.test.levellingup.gov.uk"
   environment          = "staging"
   kms_key_arn          = module.marklogic.deploy_user_kms_key_arn
-  vpc_id               = module.networking.vpc.id
+  vpce_id              = module.networking.ses_vpce_id
 }
 
 module "cpm_ses_user" {
@@ -283,7 +283,7 @@ module "cpm_ses_user" {
   from_address_pattern = "cpm-staging@datacollection.test.levellingup.gov.uk"
   environment          = "staging"
   kms_key_arn          = module.marklogic.deploy_user_kms_key_arn
-  vpc_id               = module.networking.vpc.id
+  vpce_id              = module.networking.ses_vpce_id
 }
 
 module "iam_roles" {


### PR DESCRIPTION
Emails are failing to send from CPM because of a permission error. My guess is that aws:SourceVpc isn't set (since the VPC condition was added after I tested emails) but hopefully sourceVpce is?

Not tested yet. It's not trivial to test the java emails and I tried triggering an email via the xquery console but I'm getting a networking error that I don't understand...