### PR TITLE
Use GP2 EBS volume for GitHub runner

### DIFF
--- a/terraform/modules/github_runner/instance.tf
+++ b/terraform/modules/github_runner/instance.tf
@@ -3,7 +3,7 @@ data "aws_ami" "amazon_linux" {
 
   filter {
     name   = "name"
-    values = ["amzn2-ami-hvm-*-x86_64-ebs"]
+    values = ["amzn2-ami-hvm-*-x86_64-gp2"]
   }
   owners = ["amazon"]
 }


### PR DESCRIPTION
Was wondering why "$0.055 per GB-month of Magnetic provisioned storage - EU (Ireland) 7.455 GB-Mo" is on our AWS bill, turns out "-ebs" means the old HDD volumes. Will do the same for Delta.

The GitHub runner ignores AMI changes and I haven't replaced it so this will not take effect yet.