### PR TITLE
DT-103: Increase IP rate limit for test

### DIFF
--- a/terraform/modules/cloudfront_distributions/main.tf
+++ b/terraform/modules/cloudfront_distributions/main.tf
@@ -5,32 +5,36 @@ module "access_logs_bucket" {
 }
 
 module "default_waf" {
-  source           = "../waf"
-  log_group_suffix = "default-${var.environment}"
-  prefix           = "${var.environment}-default-"
+  source            = "../waf"
+  log_group_suffix  = "default-${var.environment}"
+  prefix            = "${var.environment}-default-"
+  per_ip_rate_limit = var.waf_per_ip_rate_limit
 }
 
 module "delta_website_waf" {
-  source           = "../waf"
-  prefix           = "${var.environment}-delta-website-"
-  log_group_suffix = "delta-website-${var.environment}"
+  source            = "../waf"
+  prefix            = "${var.environment}-delta-website-"
+  log_group_suffix  = "delta-website-${var.environment}"
+  per_ip_rate_limit = var.waf_per_ip_rate_limit
   # Orbeon triggers this rule
   excluded_rules = ["CrossSiteScripting_BODY"]
 }
 
 module "cpm_waf" {
-  source           = "../waf"
-  prefix           = "${var.environment}-cpm-"
-  log_group_suffix = "cpm-${var.environment}"
+  source            = "../waf"
+  prefix            = "${var.environment}-cpm-"
+  log_group_suffix  = "cpm-${var.environment}"
+  per_ip_rate_limit = var.waf_per_ip_rate_limit
   # At least some e-claims POST requests trigger this rule
   excluded_rules = ["CrossSiteScripting_BODY"]
   ip_allowlist   = var.enable_ip_allowlists ? local.cpm_ip_allowlist : null
 }
 
 module "api_auth_waf" {
-  source           = "../waf"
-  prefix           = "${var.environment}-delta-api-"
-  log_group_suffix = "delta-api-${var.environment}"
+  source            = "../waf"
+  prefix            = "${var.environment}-delta-api-"
+  log_group_suffix  = "delta-api-${var.environment}"
+  per_ip_rate_limit = var.waf_per_ip_rate_limit
   # XSS not issue for API
   excluded_rules = ["CrossSiteScripting_BODY", "CrossSiteScripting_COOKIE", "CrossSiteScripting_QUERYARGUMENTS", "CrossSiteScripting_URIPATH"]
   ip_allowlist   = var.enable_ip_allowlists ? local.delta_api_allowlist : null

--- a/terraform/modules/cloudfront_distributions/variables.tf
+++ b/terraform/modules/cloudfront_distributions/variables.tf
@@ -15,6 +15,12 @@ variable "all_distribution_ip_allowlist" {
   type = list(string)
 }
 
+variable "waf_per_ip_rate_limit" {
+  type        = number
+  default     = 500
+  description = "The per-IP rate limit enforced by AWS WAF in requests per five minutes"
+}
+
 variable "delta" {
   type = object({
     alb = object({

--- a/terraform/modules/waf/main.tf
+++ b/terraform/modules/waf/main.tf
@@ -13,6 +13,11 @@ variable "ip_allowlist" {
   default = null
 }
 
+variable "per_ip_rate_limit" {
+  type        = number
+  description = "Requests per five minutes"
+}
+
 resource "aws_wafv2_ip_set" "main" {
   provider = aws.us-east-1
   count    = var.ip_allowlist == null ? 0 : 1
@@ -75,7 +80,7 @@ resource "aws_wafv2_web_acl" "waf_acl" {
 
     statement {
       rate_based_statement {
-        limit              = 500
+        limit              = var.per_ip_rate_limit
         aggregate_key_type = "IP"
       }
     }

--- a/terraform/test/main.tf
+++ b/terraform/test/main.tf
@@ -135,8 +135,9 @@ module "public_albs" {
 module "cloudfront_distributions" {
   source = "../modules/cloudfront_distributions"
 
-  environment  = "test"
-  base_domains = [var.primary_domain, var.secondary_domain]
+  environment           = "test"
+  base_domains          = [var.primary_domain, var.secondary_domain]
+  waf_per_ip_rate_limit = 100000
 
   # Adding 0.0.0.0/0 to an ipset is not allowed and we don't want to restrict test
   enable_ip_allowlists = false


### PR DESCRIPTION
Required for running Playwright tests against it.

We could specifically exclude some IPs from the rate limiting or something, but this is easier for the test environment.