### PR TITLE
Recreate association to pick up CloudWatch agent config changes

### DIFF
--- a/terraform/modules/jaspersoft/app_logs.tf
+++ b/terraform/modules/jaspersoft/app_logs.tf
@@ -13,19 +13,23 @@ module "jaspersoft_log_group" {
   log_group_names    = [local.app_log_group_name, local.ssm_log_group_name]
 }
 
-resource "aws_s3_object" "cloudwatch_config" {
-  content = templatefile("${path.module}/templates/cloudwatch_config.json.tftpl", {
+locals {
+  cloudwatch_config_json = templatefile("${path.module}/templates/cloudwatch_config.json.tftpl", {
     environment        = var.environment
     app_log_group_name = local.app_log_group_name
     ssm_log_group_name = local.ssm_log_group_name
   })
-  bucket = module.config_bucket.bucket
-  key    = "cloudwatch_config.json"
+}
+
+resource "aws_s3_object" "cloudwatch_config" {
+  content = local.cloudwatch_config_json
+  etag    = md5(local.cloudwatch_config_json)
+  bucket  = module.config_bucket.bucket
+  key     = "cloudwatch_config.json"
 }
 
 resource "aws_ssm_association" "install_cloudwatch_agent" {
-  depends_on       = [module.jaspersoft_log_group]
-  name             = aws_ssm_document.couldwatch_agent.name
+  name             = aws_ssm_document.cloudwatch_agent.name
   association_name = "Install-CloudwatchAgent-jaspersoft-${var.environment}"
   parameters = {
     ConfigLocation = "s3://${aws_s3_object.cloudwatch_config.bucket}/${aws_s3_object.cloudwatch_config.key}"
@@ -34,13 +38,20 @@ resource "aws_ssm_association" "install_cloudwatch_agent" {
     key    = "InstanceIds"
     values = [aws_instance.jaspersoft_server.id]
   }
+
+  depends_on = [module.jaspersoft_log_group]
+  lifecycle {
+    replace_triggered_by = [
+      aws_ssm_document.cloudwatch_agent.content,
+      aws_s3_object.cloudwatch_config.etag,
+    ]
+  }
 }
 
-resource "aws_ssm_document" "couldwatch_agent" {
-  name            = "ConfigureCloudwatchAgentJaspersoft-${var.environment}"
+resource "aws_ssm_document" "cloudwatch_agent" {
+  name            = "Jaspersoft-ConfigureCloudwatchAgent-${var.environment}"
   document_format = "YAML"
   document_type   = "Command"
 
   content = file("${path.module}/templates/cloudwatch_agent_ssm_doc.yml")
 }
-

--- a/terraform/modules/marklogic/app_logs.tf
+++ b/terraform/modules/marklogic/app_logs.tf
@@ -36,20 +36,24 @@ module "config_files_bucket" {
   access_s3_log_expiration_days = var.config_s3_log_expiration_days
 }
 
-resource "aws_s3_object" "cloudwatch_config" {
-  content = templatefile("${path.module}/templates/cloudwatch_config.json.tftpl", {
+locals {
+  cloudwatch_config_json = templatefile("${path.module}/templates/cloudwatch_config.json.tftpl", {
     environment             = var.environment
     app_log_group_base_name = local.app_log_group_base_name
     ssm_log_group_name      = local.ssm_log_group_name
     log_port_details        = local.log_port_details
   })
-  bucket = module.config_files_bucket.bucket
-  key    = "cloudwatch_config.json"
+}
+
+resource "aws_s3_object" "cloudwatch_config" {
+  content = local.cloudwatch_config_json
+  etag    = md5(local.cloudwatch_config_json)
+  bucket  = module.config_files_bucket.bucket
+  key     = "cloudwatch_config.json"
 }
 
 resource "aws_ssm_association" "install_cloudwatch_agent" {
-  depends_on       = [module.marklogic_log_group]
-  name             = aws_ssm_document.couldwatch_agent.name
+  name             = aws_ssm_document.cloudwatch_agent.name
   association_name = "Install-CloudwatchAgent-MarkLogic-${var.environment}"
   parameters = {
     ConfigLocation = "s3://${aws_s3_object.cloudwatch_config.bucket}/${aws_s3_object.cloudwatch_config.key}"
@@ -58,13 +62,20 @@ resource "aws_ssm_association" "install_cloudwatch_agent" {
     key    = "tag:marklogic:stack:name"
     values = [local.stack_name]
   }
+
+  depends_on = [module.marklogic_log_group]
+  lifecycle {
+    replace_triggered_by = [
+      aws_ssm_document.cloudwatch_agent.content,
+      aws_s3_object.cloudwatch_config.etag,
+    ]
+  }
 }
 
-resource "aws_ssm_document" "couldwatch_agent" {
-  name            = "ConfigureCloudwatchAgent-${var.environment}"
+resource "aws_ssm_document" "cloudwatch_agent" {
+  name            = "MarkLogic-ConfigureCloudwatchAgent-${var.environment}"
   document_format = "YAML"
   document_type   = "Command"
 
   content = file("${path.module}/templates/cloudwatch_agent_ssm_doc.yml")
 }
-


### PR DESCRIPTION
I fell into the trap of not re-running it when I updated test, this should make Terraform do it.