### PR TITLE
DT-54: add jasperserver.log to cloudwatch

### DIFF
--- a/terraform/modules/jaspersoft/templates/cloudwatch_config.json.tftpl
+++ b/terraform/modules/jaspersoft/templates/cloudwatch_config.json.tftpl
@@ -28,6 +28,11 @@
             "log_stream_name": "{instance_id}-host-manager"
           },
           {
+            "file_path": "/opt/tomcat/base/webapps/jasperserver/WEB-INF/logs/jasperserver.log",
+            "log_group_name": "${app_log_group_name}",
+            "log_stream_name": "{instance_id}-jasperserver"
+          },
+          {
             "file_path": "/var/log/amazon/ssm/errors.log",
             "log_group_name": "${ssm_log_group_name}",
             "log_stream_name": "errors-{instance_id}"


### PR DESCRIPTION
Not tested but there were some error messages in that file that I don't think were in the catalina/localhost logs. 