### PR TITLE
Add various groups to jasperreports-users group

### DIFF
--- a/manual_scripts/active_directory/users-to-groups.csv
+++ b/manual_scripts/active_directory/users-to-groups.csv
@@ -22,6 +22,11 @@ jasperreports-admins,jasperadminuser
 jasperreports-users,jasperuser
 jasperreports-users,jasperreports-admins
 jasperreports-admins,datamart-delta-admin
+jasperreports-users,datamart-delta-admin
+jasperreports-users,datamart-delta-report-users
+jasperreports-users,datamart-delta-sap-team-members
+jasperreports-users,datamart-delta-payments-reviewers
+jasperreports-users,datamart-delta-payments-approvers
 dluhc-service-users,keycloak
 dluhc-service-users,cpmapp
 dluhc-service-users,sap

--- a/terraform/modules/jaspersoft/install_files/applicationContext-externalAuth-LDAP.xml
+++ b/terraform/modules/jaspersoft/install_files/applicationContext-externalAuth-LDAP.xml
@@ -179,7 +179,7 @@
         </property>
         <property name="defaultInternalRoles">
             <list>
-                <!-- No default permissions, users must be in the jasperreports-users group -->
+                <!-- No default permissions, users must be in the jasperreports-users group. Delta roles get access by -->
                 <!-- <value>ROLE_USER</value> -->
             </list>
         </property>
@@ -188,6 +188,7 @@
             <map>
                 <entry>
                     <key>
+                        <!-- Users get access by having a Delta role in AD that is a member of jasperreports-users/admins-->
                         <value>ROLE_JASPERREPORTS-USERS</value>
                     </key>
                     <value>ROLE_USER</value>


### PR DESCRIPTION
Not really sure where best to document this requirement.

I'm thinking of just adding a code comment like this to AuthorityConfig.java in the delta repo:

```
// When updating which roles get access to TRANSACTION_REPORT, also update them in AD to have jasperreports-user role. See AD group setup in delta-common-infrastructure.
```