### PR TITLE
Add IP restriction for testing

### DIFF
--- a/manual_scripts/marklogic/marklogic-migration.md
+++ b/manual_scripts/marklogic/marklogic-migration.md
@@ -27,7 +27,8 @@ Afterwards:
 * Update the post-migration-update-security.xqy query with the correct list of users to delete. Run it from the MarkLogic query console, targeting the Security database.
 * Enable app servers using the script from above
 * Run the Roxy deployment jobs from <https://github.com/communitiesuk/delta-marklogic-deploy> for both Delta and CPM.
+  * Including the API
 * Delete the external security "datamart-eclaims-sec"
 * Check the external securities "datamart-cpm-sec" and "datamart-sec" were configured correctly
 * Re-enable scheduled tasks and rebalancer using the scripts from above
-* Re-enable all scheduled backups
+* Re-enable all scheduled backups/run the Action

--- a/terraform/production/ip_lists.tf
+++ b/terraform/production/ip_lists.tf
@@ -28,7 +28,20 @@ locals {
         "62.32.120.112/29",  # Home Connections
       ]
     )
-    delta_website = local.all_distribution_ip_allowlist
-    jaspersoft    = local.all_distribution_ip_allowlist
+    delta_website = concat(
+      local.all_distribution_ip_allowlist,
+      [
+        # DLUHC, for testing
+        "165.225.196.0/23",
+        "165.225.198.0/23",
+        "147.161.224.0/23",
+        "165.225.16.0/23",
+        "147.161.166.0/23",
+        "147.161.142.0/23",
+        "147.161.144.0/23",
+        "147.161.140.0/23",
+      ]
+    )
+    jaspersoft = local.all_distribution_ip_allowlist
   }
 }

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -259,8 +259,8 @@ module "cloudfront_distributions" {
       aliases             = ["delta.${var.secondary_domain}", "delta.${var.primary_domain}"]
       acm_certificate_arn = module.ssl_certs.cloudfront_certs["delta"].arn
     }
-    # TODO MIGRATION: Re-enable
-    # ip_allowlist              = local.cloudfront_ip_allowlists.delta_website
+    # TODO MIGRATION: Remove
+    ip_allowlist              = local.cloudfront_ip_allowlists.delta_website
     geo_restriction_countries = ["GB", "IE"]
     origin_read_timeout       = 180 # Required quota increase
   }


### PR DESCRIPTION
Other users will see a plain text "Delta: Service unavailable due to planned maintenance" response from waf/main.tf.