### PR TITLE
DT-281: Set Cache-Control no-store on CloudFront error page

### DIFF
--- a/terraform/modules/website_cloudfront/503.html
+++ b/terraform/modules/website_cloudfront/503.html
@@ -7,32 +7,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <meta name="theme-color" content="#0b0c0c">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <link rel="shortcut icon" sizes="16x16 32x32 48x48" href="/govuk/assets/images/favicon.ico" type="image/x-icon">
-    <link rel="mask-icon" href="/govuk/assets/images/govuk-mask-icon.svg" color="#0b0c0c">
-    <link rel="apple-touch-icon" sizes="180x180" href="/govuk/assets/images/govuk-apple-touch-icon-180x180.png">
-    <link rel="apple-touch-icon" sizes="167x167" href="/govuk/assets/images/govuk-apple-touch-icon-167x167.png">
-    <link rel="apple-touch-icon" sizes="152x152" href="/govuk/assets/images/govuk-apple-touch-icon-152x152.png">
-    <link rel="apple-touch-icon" href="/govuk/assets/images/govuk-apple-touch-icon.png">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.3.0/css/font-awesome.css" media="all"
         rel="stylesheet" type="text/css" />
 
-    <meta property="og:image" content="/govuk/assets/images/govuk-opengraph-image.png">
     <style>
-        @font-face {
-            font-family: "GDS Transport";
-            font-style: normal;
-            font-weight: normal;
-            src: url("/govuk/assets/fonts/light-94a07e06a1-v2.woff2") format("woff2"), url("/govuk/assets/fonts/light-f591b13f7d-v2.woff") format("woff");
-            font-display: fallback;
-        }
-
-        @font-face {
-            font-family: "GDS Transport";
-            font-style: normal;
-            font-weight: bold;
-            src: url("/govuk/assets/fonts/bold-b542beb274-v2.woff2") format("woff2"), url("/govuk/assets/fonts/bold-affa96571d-v2.woff") format("woff");
-            font-display: fallback;
-        }
 
         /* application.css inlined */
         .govuk-link,

--- a/terraform/modules/website_cloudfront/main.tf
+++ b/terraform/modules/website_cloudfront/main.tf
@@ -33,6 +33,37 @@ resource "aws_cloudfront_response_headers_policy" "main" {
   }
 }
 
+resource "aws_cloudfront_response_headers_policy" "static_errors" {
+  name    = "${var.prefix}cloudfront-policy-static-errors"
+  comment = "Headers for static error responses"
+
+  security_headers_config {
+    frame_options {
+      frame_option = "SAMEORIGIN"
+      override     = false
+    }
+
+    referrer_policy {
+      referrer_policy = "no-referrer"
+      override        = false
+    }
+
+    strict_transport_security {
+      access_control_max_age_sec = 31536000
+      include_subdomains         = true
+      override                   = false
+    }
+  }
+
+  custom_headers_config {
+    items {
+      header   = "Cache-Control"
+      value    = "no-store"
+      override = true
+    }
+  }
+}
+
 resource "aws_cloudfront_distribution" "main" {
   aliases = var.cloudfront_domain == null ? [] : var.cloudfront_domain.aliases
 
@@ -94,10 +125,10 @@ resource "aws_cloudfront_distribution" "main" {
     target_origin_id           = "error_origin"
     path_pattern               = "/static_errors/*"
     viewer_protocol_policy     = "redirect-to-https"
-    min_ttl                    = 0
-    default_ttl                = 60
+    min_ttl                    = 120
+    default_ttl                = 120
     max_ttl                    = 86400
-    response_headers_policy_id = aws_cloudfront_response_headers_policy.main.id
+    response_headers_policy_id = aws_cloudfront_response_headers_policy.static_errors.id
 
     forwarded_values {
       query_string = false


### PR DESCRIPTION
I think the issue was Datamart's outage page tbh, I wouldn't expect 503s to get cached. Anyway Laurence had some HTML cached over JS and CSS files, this is to make sure that won't happen if we need to put it back up.

Also good to know we can override the cache-control header if we want to.

https://delta.test.communities.gov.uk/static_errors/503.html