### PR TITLE
Adjust prod ML data disk usage alarm

### DIFF
--- a/terraform/modules/marklogic/monitoring_alarms.tf
+++ b/terraform/modules/marklogic/monitoring_alarms.tf
@@ -101,14 +101,14 @@ resource "aws_cloudwatch_metric_alarm" "data_disk_utilisation_high" {
 resource "aws_cloudwatch_metric_alarm" "data_disk_utilisation_high_sustained" {
   alarm_name          = "marklogic-${var.environment}-data-disk-used-high-sustained"
   comparison_operator = "GreaterThanThreshold"
-  evaluation_periods  = 4
+  evaluation_periods  = 6
   metric_name         = "disk_used_percent"
   namespace           = "${var.environment}/MarkLogic"
   period              = 900
   statistic           = "Maximum"
   threshold           = var.data_disk_usage_alarm_threshold_percent
 
-  alarm_description         = format(local.alarm_description_template, "Disk Usage", "High", 60)
+  alarm_description         = format(local.alarm_description_template, "Disk Usage", "High", var.data_disk_usage_alarm_threshold_percent)
   alarm_actions             = [var.alarms_sns_topic_arn]
   ok_actions                = [var.alarms_sns_topic_arn]
   insufficient_data_actions = [var.alarms_sns_topic_arn]

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -197,7 +197,7 @@ module "marklogic" {
   dap_export_s3_log_expiration_days       = local.s3_log_expiration_days
   backup_s3_log_expiration_days           = local.s3_log_expiration_days
   alarms_sns_topic_arn                    = module.notifications.alarms_sns_topic_arn
-  data_disk_usage_alarm_threshold_percent = 55
+  data_disk_usage_alarm_threshold_percent = 60
   dap_external_role_arns                  = var.dap_external_role_arns
   dap_job_notification_emails = concat(
     local.all_notifications_email_addresses,


### PR DESCRIPTION
ML disk usage seems to go through a daily cycle from ~45->55. Red line here is 50
![image](https://user-images.githubusercontent.com/10462681/222692987-5cc23ed9-87d5-488d-bb50-2c31da5bc067.png)
