### PR TITLE
DT-299: Update staging ML to 10.0-9.5

### DIFF
--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -260,7 +260,7 @@ module "marklogic" {
   vpc                      = module.networking.vpc
   private_subnets          = module.networking.ml_private_subnets
   instance_type            = "t3a.2xlarge"
-  marklogic_ami_version    = "10.0-9.2"
+  marklogic_ami_version    = "10.0-9.5"
   private_dns              = module.networking.private_dns
   patch_maintenance_window = module.marklogic_patch_maintenance_window
   data_volume = {


### PR DESCRIPTION
It was a bit messy, but done now, I think the host names in the DynamoDB table got out of sync with the ENIs somehow.
No change on `cts:triples` speed that I could see.

https://softwire.slack.com/archives/C04R0LKL19A/p1678192314912569