### PR TITLE
DT-295: remove todo

### DIFF
--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -286,7 +286,7 @@ module "cloudfront_distributions" {
     geo_restriction_countries                 = ["GB", "IE"]
     origin_read_timeout                       = 180 # Required quota increase
     server_error_rate_alarm_threshold_percent = 5
-    client_error_rate_alarm_threshold_percent = 50 # TODO: DT-295 Reduce this
+    client_error_rate_alarm_threshold_percent = 50
   }
   api = {
     alb = module.public_albs.delta_api

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -180,7 +180,7 @@ module "cloudfront_distributions" {
     # Some TSO staff are located in India (IN)
     geo_restriction_countries = ["GB", "IE", "IN"]
     # We don't want to restrict staging until we are able to confirm who needs access
-    client_error_rate_alarm_threshold_percent = 15 # TODO: DT-295 Reduce this
+    client_error_rate_alarm_threshold_percent = 15
   }
   api = {
     alb = module.public_albs.delta_api

--- a/terraform/test/main.tf
+++ b/terraform/test/main.tf
@@ -189,7 +189,7 @@ module "cloudfront_distributions" {
     # So GitHub Actions can access for end to end tests
     geo_restriction_countries = null
     # We don't want to IP restrict test (yet)
-    client_error_rate_alarm_threshold_percent = 15 # TODO: DT-295 Reduce this
+    client_error_rate_alarm_threshold_percent = 15
   }
   api = {
     alb = module.public_albs.delta_api


### PR DESCRIPTION
Client error alarm threshold should be kept high for now.