### PR TITLE
Forward host header for cached paths

### DIFF
--- a/terraform/modules/website_cloudfront/main.tf
+++ b/terraform/modules/website_cloudfront/main.tf
@@ -160,6 +160,8 @@ resource "aws_cloudfront_distribution" "main" {
         cookies {
           forward = "none"
         }
+
+        headers = ["Host"]
       }
     }
   }


### PR DESCRIPTION
Needs the host header since the ALB cert is for the main delta domain rather than the origin ALB domain we give to CloudFront.

Symptoms are 502 responses with OriginConnectError in the logs.

Will raise another PR to set `wait_for_deployment` to true for staging and production, I almost missed this as it took a minute or so for the change to break staging.