### PR TITLE
CloudFront wait for deployment on staging and prod

### DIFF
--- a/terraform/modules/api_cloudfront/main.tf
+++ b/terraform/modules/api_cloudfront/main.tf
@@ -36,7 +36,7 @@ resource "aws_cloudfront_response_headers_policy" "main" {
 resource "aws_cloudfront_distribution" "main" {
   aliases = var.cloudfront_domain == null ? [] : var.cloudfront_domain.aliases
 
-  wait_for_deployment = false
+  wait_for_deployment = var.wait_for_deployment
   default_root_object = "index.html"
 
   origin {

--- a/terraform/modules/api_cloudfront/variables.tf
+++ b/terraform/modules/api_cloudfront/variables.tf
@@ -54,3 +54,7 @@ variable "apply_aws_shield" {
 variable "swagger_s3_log_expiration_days" {
   type = number
 }
+
+variable "wait_for_deployment" {
+  type = bool
+}

--- a/terraform/modules/cloudfront_distribution/main.tf
+++ b/terraform/modules/cloudfront_distribution/main.tf
@@ -36,7 +36,7 @@ resource "aws_cloudfront_response_headers_policy" "main" {
 resource "aws_cloudfront_distribution" "main" {
   aliases = var.cloudfront_domain == null ? [] : var.cloudfront_domain.aliases
 
-  wait_for_deployment = false
+  wait_for_deployment = var.wait_for_deployment
 
   origin {
     domain_name = var.origin_domain

--- a/terraform/modules/cloudfront_distribution/variables.tf
+++ b/terraform/modules/cloudfront_distribution/variables.tf
@@ -56,3 +56,7 @@ variable "origin_read_timeout" {
   description = "Read timeout for the main origin in seconds. Note that the default quota limit for this is 60, to increase above that request a quota increase first."
   default     = 60
 }
+
+variable "wait_for_deployment" {
+  type = bool
+}

--- a/terraform/modules/cloudfront_distributions/main.tf
+++ b/terraform/modules/cloudfront_distributions/main.tf
@@ -67,6 +67,7 @@ module "delta_cloudfront" {
   geo_restriction_countries      = var.delta.geo_restriction_countries
   apply_aws_shield               = var.apply_aws_shield
   origin_read_timeout            = var.delta.origin_read_timeout == null ? 60 : var.delta.origin_read_timeout
+  wait_for_deployment            = var.wait_for_deployment
 }
 
 module "api_cloudfront" {
@@ -83,6 +84,7 @@ module "api_cloudfront" {
   environment                    = var.environment
   apply_aws_shield               = var.apply_aws_shield
   swagger_s3_log_expiration_days = var.swagger_s3_log_expiration_days
+  wait_for_deployment            = var.wait_for_deployment
 
 }
 
@@ -99,6 +101,7 @@ module "keycloak_cloudfront" {
   geo_restriction_countries      = var.keycloak.geo_restriction_countries
   apply_aws_shield               = var.apply_aws_shield
   function_associations          = [{ event_type = "viewer-request", function_arn = aws_cloudfront_function.keycloak_request.arn }]
+  wait_for_deployment            = var.wait_for_deployment
 
 }
 
@@ -116,6 +119,7 @@ module "cpm_cloudfront" {
   geo_restriction_countries      = var.cpm.geo_restriction_countries
   apply_aws_shield               = var.apply_aws_shield
   origin_read_timeout            = var.cpm.origin_read_timeout == null ? 60 : var.cpm.origin_read_timeout
+  wait_for_deployment            = var.wait_for_deployment
 }
 
 module "jaspersoft_cloudfront" {
@@ -130,4 +134,5 @@ module "jaspersoft_cloudfront" {
   is_ipv6_enabled                = var.jaspersoft.ip_allowlist == null
   geo_restriction_countries      = var.jaspersoft.geo_restriction_countries
   apply_aws_shield               = var.apply_aws_shield
+  wait_for_deployment            = var.wait_for_deployment
 }

--- a/terraform/modules/cloudfront_distributions/variables.tf
+++ b/terraform/modules/cloudfront_distributions/variables.tf
@@ -131,3 +131,7 @@ variable "alarms_sns_topic_global_arn" {
   description = "SNS topic ARN to send alarm notifications to"
   type        = string
 }
+
+variable "wait_for_deployment" {
+  type = bool
+}

--- a/terraform/modules/website_cloudfront/main.tf
+++ b/terraform/modules/website_cloudfront/main.tf
@@ -67,7 +67,7 @@ resource "aws_cloudfront_response_headers_policy" "static_errors" {
 resource "aws_cloudfront_distribution" "main" {
   aliases = var.cloudfront_domain == null ? [] : var.cloudfront_domain.aliases
 
-  wait_for_deployment = false
+  wait_for_deployment = var.wait_for_deployment
 
   origin {
     domain_name = var.origin_domain

--- a/terraform/modules/website_cloudfront/variables.tf
+++ b/terraform/modules/website_cloudfront/variables.tf
@@ -50,3 +50,7 @@ variable "origin_read_timeout" {
   type        = number
   description = "Read timeout for the website origin in seconds. Note that the default quota limit for this is 60, to increase above that request a quota increase first."
 }
+
+variable "wait_for_deployment" {
+  type = bool
+}

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -267,10 +267,11 @@ module "cloudfront_distributions" {
   base_domains                             = [var.primary_domain]
   apply_aws_shield                         = local.apply_aws_shield
   waf_cloudwatch_log_expiration_days       = local.cloudwatch_log_expiration_days
-  login_ip_rate_limit                      = 100
   cloudfront_access_s3_log_expiration_days = local.s3_log_expiration_days
   swagger_s3_log_expiration_days           = local.s3_log_expiration_days
   alarms_sns_topic_global_arn              = module.notifications.alarms_sns_topic_global_arn
+  wait_for_deployment                      = true
+
   delta = {
     alb = module.public_albs.delta
     domain = {

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -161,7 +161,7 @@ module "cloudfront_distributions" {
   cloudfront_access_s3_log_expiration_days = local.s3_log_expiration_days
   swagger_s3_log_expiration_days           = local.s3_log_expiration_days
   alarms_sns_topic_global_arn              = module.notifications.alarms_sns_topic_global_arn
-  login_ip_rate_limit                      = 100
+  wait_for_deployment                      = true
 
   delta = {
     alb = module.public_albs.delta

--- a/terraform/test/main.tf
+++ b/terraform/test/main.tf
@@ -175,6 +175,7 @@ module "cloudfront_distributions" {
   cloudfront_access_s3_log_expiration_days = local.s3_log_expiration_days
   swagger_s3_log_expiration_days           = local.s3_log_expiration_days
   alarms_sns_topic_global_arn              = module.notifications.alarms_sns_topic_global_arn
+  wait_for_deployment                      = false
 
   delta = {
     alb = module.public_albs.delta


### PR DESCRIPTION
This is a bit sad because applies that change CloudFront will now be much slower (~4 minutes), which is annoying, but it's a bit safer that way.