### PR TITLE
DT-153: Remove access from datamart to migration backup buckets

### DIFF
--- a/terraform/production/datamart_ml_export.tf
+++ b/terraform/production/datamart_ml_export.tf
@@ -1,7 +1,3 @@
-locals {
-  datamart_account_id = "090682378586"
-}
-
 module "datamart_ml_backups" {
   source = "../modules/s3_bucket"
 

--- a/terraform/staging/datamart_ml_export.tf
+++ b/terraform/staging/datamart_ml_export.tf
@@ -1,7 +1,3 @@
-locals {
-  datamart_account_id = "090682378586"
-}
-
 # MarkLogic seems to ignore the bucket level KMS settings, so this isn't used
 resource "aws_kms_key" "ml_backup_from_datamart_encryption" {
   enable_key_rotation = true


### PR DESCRIPTION
I'll then delete all the backups in these buckets apart from the most recent ones.