### PR TITLE
Checks to run on all PRs

### DIFF
--- a/.github/workflows/apply.yml
+++ b/.github/workflows/apply.yml
@@ -30,7 +30,7 @@ jobs:
         # Exposes stdout, stderr and exitcode as outputs for any steps that run terraform
         uses: hashicorp/setup-terraform@v2
         with:
-          terraform_version: 1.3.6
+          terraform_version: 1.3.9
 
       - name: Terraform init
         id: init
@@ -73,7 +73,7 @@ jobs:
       - name: Set up Terraform
         uses: hashicorp/setup-terraform@v2
         with:
-          terraform_version: 1.3.6
+          terraform_version: 1.3.9
 
       - name: Terraform init
         id: init

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Terraform
         uses: hashicorp/setup-terraform@v2
         with:
-          terraform_version: 1.3.6
+          terraform_version: 1.3.9
       - name: Check formatting of all Terraform files
         run: terraform fmt -check -diff -recursive
   tfsec:

--- a/.github/workflows/plan-validate.yml
+++ b/.github/workflows/plan-validate.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Terraform
         uses: hashicorp/setup-terraform@v2
         with:
-          terraform_version: 1.3.6
+          terraform_version: 1.3.9
       - name: Terraform init
         run: terraform init -input=false
         working-directory: terraform/test
@@ -51,7 +51,7 @@ jobs:
       - name: Set up Terraform
         uses: hashicorp/setup-terraform@v2
         with:
-          terraform_version: 1.3.6
+          terraform_version: 1.3.9
       - name: Terraform init
         run: terraform init -input=false
         working-directory: terraform/staging
@@ -76,7 +76,7 @@ jobs:
       - name: Set up Terraform
         uses: hashicorp/setup-terraform@v2
         with:
-          terraform_version: 1.3.6
+          terraform_version: 1.3.9
       - name: Terraform init
         run: terraform init -input=false -backend=false
         working-directory: terraform/production


### PR DESCRIPTION
Make `terraform fmt` and `tfsec` run on all PRs regardless of whether Terraform files change.

I've updated the branch protection rules to only require those two checks:
![image](https://user-images.githubusercontent.com/35066342/235124602-3ee84a8f-bf86-497a-b119-458a378507f5.png)

So now we can make changes to docs etc. without having to override the rules.

Also update Terraform to 1.3.9 (latest is 1.4.6).