### PR TITLE
Remove tomcat pid file when rebooting for scheduled patch

### DIFF
--- a/terraform/modules/jaspersoft/patch.sh
+++ b/terraform/modules/jaspersoft/patch.sh
@@ -11,6 +11,10 @@ echo "Apt updates complete"
 
 if [ -f /var/run/reboot-required ]; then
   echo "/var/run/reboot-required exists, requesting reboot from SSM agent at $(date --iso-8601=seconds)"
+  # We are confident tomcat will stop because we are rebooting, but it does not reliably delete the .pid file
+  # So let's just delete it explicitly to avoid the possibility that tomcat fails to restart 
+  rm -f /opt/tomcat/latest/temp/tomcat.pid
+
   exit 194 # Reboot and re-run the script https://docs.aws.amazon.com/systems-manager/latest/userguide/send-commands-reboot.html
 fi
 

--- a/terraform/modules/jaspersoft/setup_script.sh
+++ b/terraform/modules/jaspersoft/setup_script.sh
@@ -2,7 +2,7 @@
 
 set -exuo pipefail
 
-export TOMCAT_VERSION=9.0.70
+export TOMCAT_VERSION=9.0.73
 export DEBIAN_FRONTEND=noninteractive
 
 # Let the instance finish booting


### PR DESCRIPTION
I looked into creating a reboot script (e.g. an init.d file) to remove it, but I think we may as well keep it simple and remove the file as part of the patch script. 

I can create an init.d file instead if you think we should make it more robust.  