### PR TITLE
DT-399: adjust ml instance profile to avoid error

### DIFF
--- a/terraform/modules/marklogic/app_logs.tf
+++ b/terraform/modules/marklogic/app_logs.tf
@@ -2,7 +2,7 @@
 
 locals {
   app_log_group_base_name         = "${var.environment}/marklogic"
-  ssm_log_group_name              = "${var.environment}/marklogic-ssm"
+  ssm_log_group_name              = "${local.app_log_group_base_name}-ssm"
   taskserver_error_log_group_name = "${local.app_log_group_base_name}-taskserver-error"
 }
 

--- a/terraform/modules/marklogic/dap_export_s3.tf
+++ b/terraform/modules/marklogic/dap_export_s3.tf
@@ -88,7 +88,7 @@ resource "aws_ssm_maintenance_window_target" "ml_server" {
 # Non sensitive job output
 # tfsec:ignore:aws-cloudwatch-log-group-customer-key
 resource "aws_cloudwatch_log_group" "dap_upload" {
-  name              = "${var.environment}/marklogic/dap-upload-task"
+  name              = "${local.app_log_group_base_name}/dap-upload-task"
   retention_in_days = var.patch_cloudwatch_log_expiration_days
 }
 

--- a/terraform/modules/marklogic/marklogic_iam.tf
+++ b/terraform/modules/marklogic/marklogic_iam.tf
@@ -208,7 +208,7 @@ data "aws_iam_policy_document" "ml_cloudwatch" {
       "logs:DescribeLogStreams",
       "logs:PutLogEvents",
     ]
-    resources = concat(["${aws_cloudwatch_log_group.ml_patch.arn}:*", "${aws_cloudwatch_log_group.dap_upload.arn}:*"], [for arn in module.marklogic_log_group.log_group_arns : "${arn}:*"])
+    resources = ["${local.app_log_group_base_name}*"]
   }
 
   statement {

--- a/terraform/modules/marklogic/patching.tf
+++ b/terraform/modules/marklogic/patching.tf
@@ -24,7 +24,7 @@ resource "aws_ssm_maintenance_window_target" "ml_servers" {
 # Yum update output, non-sensitive
 # tfsec:ignore:aws-cloudwatch-log-group-customer-key
 resource "aws_cloudwatch_log_group" "ml_patch" {
-  name              = "${var.environment}/marklogic-ssm-patch"
+  name              = "${local.app_log_group_base_name}-ssm-patch"
   retention_in_days = var.patch_cloudwatch_log_expiration_days
 }
 


### PR DESCRIPTION
"Cannot exceed quota for PolicySize: 6144"

This doesn't change any log group names, just refactor to help ensure the log groups all share the production/marklogic prefix.

DAP upload task is slightly inconsistent with an extra slash after marklogic, but this wildcarding will still work