### PR TITLE
DT-302: Do not request or send sequenceToken from SES lambda

### DIFF
--- a/terraform/modules/ses_identity/lambdaFunction.py
+++ b/terraform/modules/ses_identity/lambdaFunction.py
@@ -6,49 +6,41 @@ import sys
 import secrets
 import os
 import logging
+
 client = boto3.client('logs')
 log_group = os.getenv("group_name")
 event_type = os.getenv("event_type")
+log_level = str(os.getenv('log_level')).upper()
 event_types = event_type.split(",")
+
 def lambda_handler(event, context):
     global log_level
-    log_level = str(os.environ.get('LOG_LEVEL')).upper()
-    if log_level not in [
-                              'DEBUG', 'INFO',
-                              'WARNING', 'ERROR',
-                              'CRITICAL'
-                          ]:
+    if log_level not in ['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL']:
         log_level = 'ERROR'
     logging.getLogger().setLevel(log_level)
     logging.info(event)
     for record in event['Records']:
-      logs = record['Sns']['Message']
-      logs_data = json.loads(logs)
-      notification_type=logs_data['notificationType']
-      if(notification_type in event_types):
-          LOG_GROUP= log_group
-      else:
-          sys.exit()
-      LOG_STREAM= '{}{}'.format(time.strftime('%Y/%m/%d'),secrets.token_hex(16))
-      try:
-          client.create_log_stream(logGroupName=LOG_GROUP, logStreamName=LOG_STREAM)
-      except client.exceptions.ResourceAlreadyExistsException:
-          pass
-      response = client.describe_log_streams(
-          logGroupName=LOG_GROUP,
-          logStreamNamePrefix=LOG_STREAM
-      )
-      event_log = {
-          'logGroupName': LOG_GROUP,
-          'logStreamName': LOG_STREAM,
-          'logEvents': [
-              {
-                  'timestamp': int(round(time.time() * 1000)),
-                  'message': logs
-              }
-          ],
-      }
-      if 'uploadSequenceToken' in response['logStreams'][0]:
-          event_log.update({'sequenceToken': response['logStreams'][0] ['uploadSequenceToken']})
-      response = client.put_log_events(**event_log)
-      logging.info(response)
+        logs = record['Sns']['Message']
+        logs_data = json.loads(logs)
+        notification_type = logs_data['notificationType']
+        if not(notification_type in event_types):
+            logging.debug("Ignoring event " + notification_type)
+            sys.exit()
+        log_stream = time.strftime('%Y/%m/%d') + "-" + notification_type
+        try:
+            client.create_log_stream(logGroupName=log_group, logStreamName=log_stream)
+            logging.debug("Created log stream " + log_stream)
+        except client.exceptions.ResourceAlreadyExistsException:
+            logging.debug("Log stream already exists " + log_stream)
+        event_log = {
+            'logGroupName': log_group,
+            'logStreamName': log_stream,
+            'logEvents': [
+                {
+                    'timestamp': int(round(time.time() * 1000)),
+                    'message': logs
+                }
+            ],
+        }
+        response = client.put_log_events(**event_log)
+        logging.info(response)


### PR DESCRIPTION
Looks like it's not required anymore and sometimes isn't returned which causes the lambda to error.

<https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_PutLogEvents.html>

> The sequence token is now ignored in `PutLogEvents` actions. `PutLogEvents` actions are always accepted and never return `InvalidSequenceTokenException` or `DataAlreadyAcceptedException` even if the sequence token is not valid. You can use parallel `PutLogEvents` actions on the same log stream.

Tested on staging.