### PR TITLE
DT-412: Migrate JasperReports to Amazon Linux and update Tomcat to 9.0.75

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ It can be run using Docker
 docker run --pull=always --rm -it -v "$(pwd):/src" aquasec/tfsec /src
 ```
 
-It's also available via Chocolately + other package managers, but the Docker image seems to be more up to date.
+It's also available via Chocolatey + other package managers, but the Docker image seems to be more up to date.
 
 Individual rules can be ignored with a comment on the line above with the form `tfsec:ignore:<rule-name>`
 e.g. `tfsec:ignore:aws-dynamodb-enable-at-rest-encryption`.

--- a/terraform/modules/jaspersoft/README.md
+++ b/terraform/modules/jaspersoft/README.md
@@ -82,15 +82,17 @@ aws s3 cp js-7.8.1_hotfixed_2022-04-15.zip s3://dluhc-jaspersoft-bin
 
 Change `TOMCAT_VERSION` to the updated version.
 
+Run as root (`sudo su`)
+
 ```sh
 # cd into the Tomcat folder
 cd /opt/tomcat
 # Note the current version, look for the target of the latest symlink
 ls -l
 # Stop tomcat
-sudo systemctl stop tomcat
+systemctl stop tomcat
 # Delete symlink
-sudo rm latest
+rm -f latest
 
 # Install new version
 TOMCAT_VERSION=9.0.70
@@ -101,10 +103,10 @@ rm -f /tmp/apache-tomcat-${TOMCAT_VERSION}.tar.gz
 # Recreate symlink
 sudo -u tomcat ln -s /opt/tomcat/apache-tomcat-${TOMCAT_VERSION} /opt/tomcat/latest
 # Restart tomcat
-sudo systemctl start tomcat
+systemctl start tomcat
 # Tail the logs while it starts, takes about a minute
 # Fine to ignore OperationNotSupportedException: Context is read only
-sudo tail -f base/logs/catalina.out
+tail -f base/logs/catalina.out
 ```
 
 Check it's working again. If something goes wrong try deleting base/work and base/temp and restarting Tomcat again.

--- a/terraform/modules/jaspersoft/install_files/tomcat.service
+++ b/terraform/modules/jaspersoft/install_files/tomcat.service
@@ -8,7 +8,7 @@ Type=forking
 User=tomcat
 Group=tomcat
 
-Environment="JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64"
+Environment="JAVA_HOME=/usr/lib/jvm/java-11-amazon-corretto.x86_64"
 
 Environment="CATALINA_BASE=/opt/tomcat/base"
 Environment="CATALINA_HOME=/opt/tomcat/latest"

--- a/terraform/modules/jaspersoft/instance.tf
+++ b/terraform/modules/jaspersoft/instance.tf
@@ -40,29 +40,18 @@ data "aws_secretsmanager_secret" "ldap_bind_password" {
   name = "jasperserver-ldap-bind-password-${var.environment}"
 }
 
-data "aws_ami" "ubuntu" {
+data "aws_ami" "amazon_linux" {
   most_recent = true
 
   filter {
     name   = "name"
-    values = ["ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-*"]
+    values = ["amzn2-ami-hvm-*-x86_64-gp2"]
   }
-
-  filter {
-    name   = "virtualization-type"
-    values = ["hvm"]
-  }
-
-  filter {
-    name   = "root-device-type"
-    values = ["ebs"]
-  }
-
-  owners = ["099720109477"] # Canonical
+  owners = ["amazon"]
 }
 
 resource "aws_instance" "jaspersoft_server" {
-  ami           = data.aws_ami.ubuntu.id
+  ami           = data.aws_ami.amazon_linux.id
   instance_type = var.instance_type
   tags          = { Name = "${var.prefix}jaspersoft-server" }
 

--- a/terraform/modules/jaspersoft/patch.sh
+++ b/terraform/modules/jaspersoft/patch.sh
@@ -4,17 +4,18 @@ set -euo pipefail
 
 echo "Script starting at $(date --iso-8601=seconds)"
 
-apt-get update
-apt-get upgrade -y
+yum update
 
-echo "Apt updates complete"
+echo "Yum updates complete"
 
-if [ -f /var/run/reboot-required ]; then
-  echo "/var/run/reboot-required exists, requesting reboot from SSM agent at $(date --iso-8601=seconds)"
+if ! needs-restarting -r; then
+  echo "Needs restart, Shutting down Tomcat at $(date --iso-8601=seconds)"
+  systemctl stop tomcat
   # We are confident tomcat will stop because we are rebooting, but it does not reliably delete the .pid file
   # So let's just delete it explicitly to avoid the possibility that tomcat fails to restart 
   rm -f /opt/tomcat/latest/temp/tomcat.pid
 
+  echo "Requesting reboot from SSM agent at $(date --iso-8601=seconds)"
   exit 194 # Reboot and re-run the script https://docs.aws.amazon.com/systems-manager/latest/userguide/send-commands-reboot.html
 fi
 

--- a/terraform/modules/networking/firewall.tf
+++ b/terraform/modules/networking/firewall.tf
@@ -301,7 +301,7 @@ locals {
   subnet_firewall_rules = [
     for name, config in local.firewall_config : join("\n", ["# ${name}",
       config.http_allowed_domains == [] && config.tls_allowed_domains == [] ?
-      "drop ip ${config.cidr} any <> any any (msg:\"Drop all traffic from ${name}\" ;sid:${config.sid_offset}; rev:1;)"
+      "drop ip ${config.cidr} any <> any any (msg:\"Drop all traffic from ${name}\"; sid:${config.sid_offset}; rev:1;)"
       : join("\n", concat(
         [
           for idx, http_domain in config.http_allowed_domains : startswith(http_domain, ".")

--- a/terraform/modules/networking/main.tf
+++ b/terraform/modules/networking/main.tf
@@ -10,15 +10,10 @@ locals {
       sid_offset           = 100
     }
     jaspersoft = {
-      cidr = local.jaspersoft_cidr_10
-      http_allowed_domains = [
-        ".ubuntu.com", ".launchpad.net", # Apt updates
-        ".postgresql.org",               # Postgres
-      ]
+      cidr                 = local.jaspersoft_cidr_10
+      http_allowed_domains = []
       tls_allowed_domains = [
-        ".ubuntu.com", ".launchpad.net",             # Apt updates
-        "archive.apache.org", ".postgresql.org",     # Tomcat + Postgres
-        "api.snapcraft.io", ".snapcraftcontent.com", # Snap updates
+        "archive.apache.org", # to download Tomcat
       ]
       sid_offset = 200
     }


### PR DESCRIPTION
Ubuntu 18.04 (which it was using before) is EOL at the end of this month. Moved to Amazon Linux 2 for consistency with the other servers. It's not officially supported by Jaspersoft but seems to work fine.

I've also:

* Switched to Corretto 11 to match Delta
* Updated Tomcat to 9.0.75

Deployed to test and checked the Active Users report still works.

I'll need to figure out how to deploy it to prod, probably `terraform rm` the old server and leave it until we're happy this one works.