### PR TITLE
DT-374 Add auth server to ML firewall allowlist

### DIFF
--- a/terraform/modules/networking/main.tf
+++ b/terraform/modules/networking/main.tf
@@ -110,12 +110,16 @@ locals {
     marklogic = {
       cidr                 = local.ml_subnet_cidr_10
       http_allowed_domains = concat(["repo.ius.io", "mirrors.fedoraproject.org"])
-      tls_allowed_domains = concat(local.marklogic_repo_mirror_tls_domains, [
-        ".marklogic.com",
-        "repo.ius.io", "mirrors.fedoraproject.org",                        # Yum repos
-        "dynamodb.us-east-1.amazonaws.com", "sns.us-east-1.amazonaws.com", # The instances make some requests to us-east-1 services on startup
-        "d2lzkl7pfhq30w.cloudfront.net",                                   # Used by MarkLogic's AMI yum updates, unclear why
-      ])
+      tls_allowed_domains = concat(
+        local.marklogic_repo_mirror_tls_domains,
+        [
+          ".marklogic.com",
+          "repo.ius.io", "mirrors.fedoraproject.org",                        # Yum repos
+          "dynamodb.us-east-1.amazonaws.com", "sns.us-east-1.amazonaws.com", # The instances make some requests to us-east-1 services on startup
+          "d2lzkl7pfhq30w.cloudfront.net",                                   # Used by MarkLogic's AMI yum updates, unclear why
+        ],
+        var.auth_server_domains # Used to fetch access tokens to communicate with Orbeon through the API, those connections are internal
+      )
       sid_offset = 4000
     }
   }


### PR DESCRIPTION
So that it can talk to Keycloak, to get an auth token, to send to the API to exchange for a SAML token to send to Orbeon to send back to MarkLogic. 😢 

At some point I'll try and set up DNS split-horizon and keep this internal, but adding it to the firewall for now, same as the API itself.