### PR TITLE
Reduce WAF rate limit and alarm thresholds

### DIFF
--- a/terraform/modules/cloudfront_distributions/variables.tf
+++ b/terraform/modules/cloudfront_distributions/variables.tf
@@ -8,7 +8,7 @@ variable "environment" {
 
 variable "waf_per_ip_rate_limit" {
   type        = number
-  default     = 2000
+  default     = 1000
   description = "The per-IP rate limit enforced by AWS WAF in requests per five minutes"
 }
 

--- a/terraform/modules/waf/monitoring.tf
+++ b/terraform/modules/waf/monitoring.tf
@@ -119,7 +119,7 @@ resource "aws_cloudwatch_metric_alarm" "blocked_requests" {
   namespace           = "AWS/WAFV2"
   period              = "300"
   statistic           = "Sum"
-  threshold           = "1000"
+  threshold           = "100"
   alarm_description   = "WAF ${aws_wafv2_web_acl.waf_acl.name} blocking large number of requests"
   treat_missing_data  = "notBreaching"
   dimensions = {


### PR DESCRIPTION
For the Delta website:
* The per IP rate limit hasn't blocked any requests
* The highest number of blocked requests in a five minute period over the last six weeks is 14