### PR TITLE
Add Logs Insights saved query for SES

### DIFF
--- a/terraform/modules/ses_identity/logs_query.tf
+++ b/terraform/modules/ses_identity/logs_query.tf
@@ -1,0 +1,19 @@
+resource "aws_cloudwatch_query_definition" "ses-deliveries" {
+  name = "${var.environment}/ses-deliveries-tf"
+
+  log_group_names = [local.log_group_name_delivered]
+
+  query_string = <<EOF
+fields @timestamp, mail.destination.0, mail.commonHeaders.subject
+EOF
+}
+
+resource "aws_cloudwatch_query_definition" "ses-problems" {
+  name = "${var.environment}/ses-problems-tf"
+
+  log_group_names = [local.log_group_name_problem]
+
+  query_string = <<EOF
+fields @timestamp, mail.destination.0, bounce.bounceSubType, mail.commonHeaders.subject
+EOF
+}


### PR DESCRIPTION
We've now got AWS accounts set up for the Delta internal support team. Adding a couple of simple queries to Terraform for them to use to see SES errors