### PR TITLE
DT 460: setting up auth service terraform

### DIFF
--- a/terraform/modules/networking/main.tf
+++ b/terraform/modules/networking/main.tf
@@ -107,6 +107,13 @@ locals {
       tls_allowed_domains  = []
       sid_offset           = 1200
     }
+    auth_service = {
+      subnets              = aws_subnet.auth_service
+      cidr                 = local.auth_service_cidr_10
+      http_allowed_domains = []
+      tls_allowed_domains  = []
+      sid_offset           = 1300
+    }
     marklogic = {
       cidr                 = local.ml_subnet_cidr_10
       http_allowed_domains = concat(["repo.ius.io", "mirrors.fedoraproject.org"])
@@ -134,6 +141,7 @@ locals {
     aws_subnet.keycloak_private,
     aws_subnet.mailhog,
     aws_subnet.jaspersoft,
+    aws_subnet.auth_service,
     [aws_subnet.ldaps_ca_server, aws_subnet.ad_management_server, aws_subnet.github_runner]
   )
 

--- a/terraform/modules/networking/outputs.tf
+++ b/terraform/modules/networking/outputs.tf
@@ -80,6 +80,11 @@ output "redis_private_subnets" {
   description = "Private /24 subnets for redis"
 }
 
+output "auth_service_private_subnets" {
+  value       = aws_subnet.auth_service
+  description = "Private /24 subnets for auth service"
+}
+
 output "private_dns" {
   value = {
     zone_id     = aws_route53_zone.private.zone_id

--- a/terraform/modules/networking/subnet.tf
+++ b/terraform/modules/networking/subnet.tf
@@ -18,6 +18,7 @@ locals {
   delta_website_cidr_10    = cidrsubnet(aws_vpc.vpc.cidr_block, 6, 11)  # 44.0/22
   mailhog_cidr_10          = cidrsubnet(aws_vpc.vpc.cidr_block, 6, 12)  # 48.0/22
   redis_cidr_10            = cidrsubnet(aws_vpc.vpc.cidr_block, 6, 13)  # 52.0/22
+  auth_service_cidr_10     = cidrsubnet(aws_vpc.vpc.cidr_block, 6, 14)  # 56.0/22
   public_cidr_10           = cidrsubnet(aws_vpc.vpc.cidr_block, 6, 32)  # 128.0/22
   firewall_cidr_8          = cidrsubnet(aws_vpc.vpc.cidr_block, 8, 254) # 254.0/24
   nat_gateway_cidr_8       = cidrsubnet(aws_vpc.vpc.cidr_block, 8, 255) # 255.0/24
@@ -176,5 +177,14 @@ resource "aws_subnet" "redis" {
   vpc_id                  = aws_vpc.vpc.id
   availability_zone       = data.aws_availability_zones.available.names[count.index]
   map_public_ip_on_launch = false
-  tags                    = { Name = "redis-private-subnet-${var.environment}" }
+  tags                    = { Name = "redis-private-subnet-${data.aws_availability_zones.available.names[count.index]}-${var.environment}" }
+}
+
+resource "aws_subnet" "auth_service" {
+  count                   = 3
+  cidr_block              = cidrsubnet(local.auth_service_cidr_10, 2, count.index)
+  vpc_id                  = aws_vpc.vpc.id
+  availability_zone       = data.aws_availability_zones.available.names[count.index]
+  map_public_ip_on_launch = false
+  tags                    = { Name = "auth-service-private-subnet-${data.aws_availability_zones.available.names[count.index]}-${var.environment}" }
 }

--- a/terraform/modules/public_albs/main.tf
+++ b/terraform/modules/public_albs/main.tf
@@ -35,9 +35,14 @@ variable "alb_s3_log_expiration_days" {
 
 # These are sent by CloudFront in the X-Cloudfront-Key header and verified by the ALB listeners
 resource "random_password" "cloudfront_keys" {
-  for_each = toset(["delta", "api", "keycloak", "cpm", "jaspersoft"])
+  for_each = toset(["delta", "api", "auth", "cpm", "jaspersoft"])
   length   = 24
   special  = false
+}
+
+moved {
+  from = random_password.cloudfront_keys["keycloak"]
+  to   = random_password.cloudfront_keys["auth"]
 }
 
 module "delta_alb" {
@@ -97,13 +102,13 @@ moved {
   to   = module.auth_alb
 }
 
-output "keycloak" {
+output "auth" {
   value = {
     arn               = module.auth_alb.arn
     arn_suffix        = module.auth_alb.arn_suffix
     dns_name          = module.auth_alb.dns_name
     security_group_id = module.auth_alb.security_group_id
-    cloudfront_key    = random_password.cloudfront_keys["keycloak"].result
+    cloudfront_key    = random_password.cloudfront_keys["auth"].result
     certificate_arn   = var.certificates["keycloak"].arn
     primary_hostname  = var.certificates["keycloak"].primary_domain
   }

--- a/terraform/modules/public_albs/main.tf
+++ b/terraform/modules/public_albs/main.tf
@@ -83,7 +83,7 @@ output "delta_api" {
   }
 }
 
-module "keycloak_alb" {
+module "auth_alb" {
   source = "../public_alb"
 
   vpc                    = var.vpc
@@ -92,12 +92,17 @@ module "keycloak_alb" {
   s3_log_expiration_days = var.alb_s3_log_expiration_days
 }
 
+moved {
+  from = module.keycloak_alb
+  to   = module.auth_alb
+}
+
 output "keycloak" {
   value = {
-    arn               = module.keycloak_alb.arn
-    arn_suffix        = module.keycloak_alb.arn_suffix
-    dns_name          = module.keycloak_alb.dns_name
-    security_group_id = module.keycloak_alb.security_group_id
+    arn               = module.auth_alb.arn
+    arn_suffix        = module.auth_alb.arn_suffix
+    dns_name          = module.auth_alb.dns_name
+    security_group_id = module.auth_alb.security_group_id
     cloudfront_key    = random_password.cloudfront_keys["keycloak"].result
     certificate_arn   = var.certificates["keycloak"].arn
     primary_hostname  = var.certificates["keycloak"].primary_domain

--- a/terraform/production/ecr.tf
+++ b/terraform/production/ecr.tf
@@ -22,6 +22,15 @@ resource "aws_iam_user" "delta_ci" {
   }
 }
 
+# tfsec:ignore:aws-iam-no-user-attached-policies
+resource "aws_iam_user" "delta_auth_ci" {
+  name = "delta-auth-ci"
+
+  lifecycle {
+    ignore_changes = [tags, tags_all] # AWS uses tags for access key descriptions
+  }
+}
+
 locals {
   repositories = {
     "cpm" = {
@@ -43,6 +52,10 @@ locals {
     "keycloak" = {
       repo_name = "keycloak",
       push_user = aws_iam_user.delta_ci.name
+    },
+    "auth_service" = {
+      repo_name = "delta-auth-service",
+      push_user = aws_iam_user.delta_auth_ci.name
     },
   }
 }

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -404,3 +404,21 @@ module "notifications" {
   alarm_sns_topic_emails    = local.all_notifications_email_addresses
   security_sns_topic_emails = local.all_notifications_email_addresses
 }
+
+#The auth alb is shared by keycloak and the auth service so we define the listener here and the rules in each repository
+resource "aws_lb_listener" "auth" {
+  load_balancer_arn = module.public_albs.keycloak.arn
+  port              = 443
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-FS-1-2-Res-2019-08"
+  certificate_arn   = module.public_albs.keycloak.certificate_arn
+
+  default_action {
+    type = "fixed-response"
+    fixed_response {
+      content_type = "text/plain"
+      message_body = "Unknown route"
+      status_code  = "404"
+    }
+  }
+}

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -247,7 +247,7 @@ module "cloudfront_alb_monitoring" {
   }
   keycloak = {
     cloudfront_distribution_id = module.cloudfront_distributions.keycloak_cloudfront_distribution_id
-    alb_arn_suffix             = module.public_albs.keycloak.arn_suffix
+    alb_arn_suffix             = module.public_albs.auth.arn_suffix
     instance_metric_namespace  = null
   }
   cpm = {
@@ -302,7 +302,7 @@ module "cloudfront_distributions" {
     geo_restriction_countries = null
   }
   keycloak = {
-    alb = module.public_albs.keycloak
+    alb = module.public_albs.auth
     domain = {
       aliases             = ["auth.delta.${var.primary_domain}"]
       acm_certificate_arn = module.communities_only_ssl_certs.cloudfront_certs["keycloak"].arn
@@ -407,11 +407,11 @@ module "notifications" {
 
 #The auth alb is shared by keycloak and the auth service so we define the listener here and the rules in each repository
 resource "aws_lb_listener" "auth" {
-  load_balancer_arn = module.public_albs.keycloak.arn
+  load_balancer_arn = module.public_albs.auth.arn
   port              = 443
   protocol          = "HTTPS"
   ssl_policy        = "ELBSecurityPolicy-FS-1-2-Res-2019-08"
-  certificate_arn   = module.public_albs.keycloak.certificate_arn
+  certificate_arn   = module.public_albs.auth.certificate_arn
 
   default_action {
     type = "fixed-response"

--- a/terraform/production/outputs.tf
+++ b/terraform/production/outputs.tf
@@ -26,6 +26,10 @@ output "redis_private_subnet_ids" {
   value = module.networking.redis_private_subnets[*].id
 }
 
+output "auth_service_private_subnet_ids" {
+  value = module.networking.auth_service_private_subnets[*].id
+}
+
 output "vpc_id" {
   value = module.networking.vpc.id
 }

--- a/terraform/production/outputs.tf
+++ b/terraform/production/outputs.tf
@@ -99,7 +99,7 @@ output "public_albs" {
   value = {
     delta      = module.public_albs.delta
     api        = module.public_albs.delta_api
-    keycloak   = module.public_albs.keycloak
+    auth       = module.public_albs.auth
     cpm        = module.public_albs.cpm
     jaspersoft = module.public_albs.jaspersoft
   }

--- a/terraform/production/outputs.tf
+++ b/terraform/production/outputs.tf
@@ -134,3 +134,7 @@ output "security_sns_topic_global_arn" {
 output "deploy_user_kms_key_arn" {
   value = module.marklogic.deploy_user_kms_key_arn
 }
+
+output "auth_listener_arn" {
+  value = aws_lb_listener.auth.arn
+}

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -397,3 +397,21 @@ module "guardduty" {
 
   aws_security_topic_arn = module.notifications.security_sns_topic_arn
 }
+
+#The auth alb is shared by keycloak and the auth service so we define the listener here and the rules in each repository
+resource "aws_lb_listener" "auth" {
+  load_balancer_arn = module.public_albs.keycloak.arn
+  port              = 443
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-FS-1-2-Res-2019-08"
+  certificate_arn   = module.public_albs.keycloak.certificate_arn
+
+  default_action {
+    type = "fixed-response"
+    fixed_response {
+      content_type = "text/plain"
+      message_body = "Unknown route"
+      status_code  = "404"
+    }
+  }
+}

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -134,7 +134,7 @@ module "cloudfront_alb_monitoring" {
   }
   keycloak = {
     cloudfront_distribution_id = module.cloudfront_distributions.keycloak_cloudfront_distribution_id
-    alb_arn_suffix             = module.public_albs.keycloak.arn_suffix
+    alb_arn_suffix             = module.public_albs.auth.arn_suffix
     instance_metric_namespace  = null
   }
   cpm = {
@@ -189,7 +189,7 @@ module "cloudfront_distributions" {
     geo_restriction_countries = null
   }
   keycloak = {
-    alb = module.public_albs.keycloak
+    alb = module.public_albs.auth
     domain = {
       aliases             = ["auth.delta.${var.primary_domain}"]
       acm_certificate_arn = module.communities_only_ssl_certs.cloudfront_certs["keycloak"].arn
@@ -400,11 +400,11 @@ module "guardduty" {
 
 #The auth alb is shared by keycloak and the auth service so we define the listener here and the rules in each repository
 resource "aws_lb_listener" "auth" {
-  load_balancer_arn = module.public_albs.keycloak.arn
+  load_balancer_arn = module.public_albs.auth.arn
   port              = 443
   protocol          = "HTTPS"
   ssl_policy        = "ELBSecurityPolicy-FS-1-2-Res-2019-08"
-  certificate_arn   = module.public_albs.keycloak.certificate_arn
+  certificate_arn   = module.public_albs.auth.certificate_arn
 
   default_action {
     type = "fixed-response"

--- a/terraform/staging/outputs.tf
+++ b/terraform/staging/outputs.tf
@@ -147,3 +147,7 @@ output "security_sns_topic_global_arn" {
 output "deploy_user_kms_key_arn" {
   value = module.marklogic.deploy_user_kms_key_arn
 }
+
+output "auth_listener_arn" {
+  value = aws_lb_listener.auth.arn
+}

--- a/terraform/staging/outputs.tf
+++ b/terraform/staging/outputs.tf
@@ -78,6 +78,10 @@ output "redis_private_subnet_ids" {
   value = module.networking.redis_private_subnets[*].id
 }
 
+output "auth_service_private_subnet_ids" {
+  value = module.networking.auth_service_private_subnets[*].id
+}
+
 output "gh_runner_private_key" {
   value     = module.gh_runner.private_key
   sensitive = true

--- a/terraform/staging/outputs.tf
+++ b/terraform/staging/outputs.tf
@@ -112,7 +112,7 @@ output "public_albs" {
   value = {
     delta      = module.public_albs.delta
     api        = module.public_albs.delta_api
-    keycloak   = module.public_albs.keycloak
+    auth       = module.public_albs.auth
     cpm        = module.public_albs.cpm
     jaspersoft = module.public_albs.jaspersoft
   }

--- a/terraform/test/main.tf
+++ b/terraform/test/main.tf
@@ -156,7 +156,7 @@ module "cloudfront_alb_monitoring" {
   }
   keycloak = {
     cloudfront_distribution_id = module.cloudfront_distributions.keycloak_cloudfront_distribution_id
-    alb_arn_suffix             = module.public_albs.keycloak.arn_suffix
+    alb_arn_suffix             = module.public_albs.auth.arn_suffix
     instance_metric_namespace  = null
   }
   cpm = {
@@ -216,7 +216,7 @@ module "cloudfront_distributions" {
     geo_restriction_countries = ["GB", "IE"]
   }
   keycloak = {
-    alb = module.public_albs.keycloak
+    alb = module.public_albs.auth
     domain = {
       aliases             = ["auth.delta.${var.primary_domain}"]
       acm_certificate_arn = module.communities_only_ssl_certs.cloudfront_certs["keycloak"].arn
@@ -416,11 +416,11 @@ module "notifications" {
 
 #The auth alb is shared by keycloak and the auth service so we define the listener here and the rules in each repository
 resource "aws_lb_listener" "auth" {
-  load_balancer_arn = module.public_albs.keycloak.arn
+  load_balancer_arn = module.public_albs.auth.arn
   port              = 443
   protocol          = "HTTPS"
   ssl_policy        = "ELBSecurityPolicy-FS-1-2-Res-2019-08"
-  certificate_arn   = module.public_albs.keycloak.certificate_arn
+  certificate_arn   = module.public_albs.auth.certificate_arn
 
   default_action {
     type = "fixed-response"

--- a/terraform/test/main.tf
+++ b/terraform/test/main.tf
@@ -413,3 +413,21 @@ module "notifications" {
   alarm_sns_topic_emails    = local.all_notifications_email_addresses
   security_sns_topic_emails = local.all_notifications_email_addresses
 }
+
+#The auth alb is shared by keycloak and the auth service so we define the listener here and the rules in each repository
+resource "aws_lb_listener" "auth" {
+  load_balancer_arn = module.public_albs.keycloak.arn
+  port              = 443
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-FS-1-2-Res-2019-08"
+  certificate_arn   = module.public_albs.keycloak.certificate_arn
+
+  default_action {
+    type = "fixed-response"
+    fixed_response {
+      content_type = "text/plain"
+      message_body = "Unknown route"
+      status_code  = "404"
+    }
+  }
+}

--- a/terraform/test/outputs.tf
+++ b/terraform/test/outputs.tf
@@ -162,3 +162,7 @@ output "security_sns_topic_global_arn" {
 output "deploy_user_kms_key_arn" {
   value = module.marklogic.deploy_user_kms_key_arn
 }
+
+output "auth_listener_arn" {
+  value = aws_lb_listener.auth.arn
+}

--- a/terraform/test/outputs.tf
+++ b/terraform/test/outputs.tf
@@ -98,6 +98,10 @@ output "redis_private_subnet_ids" {
   value = module.networking.redis_private_subnets[*].id
 }
 
+output "auth_service_private_subnet_ids" {
+  value = module.networking.auth_service_private_subnets[*].id
+}
+
 output "vpc_id" {
   value = module.networking.vpc.id
 }

--- a/terraform/test/outputs.tf
+++ b/terraform/test/outputs.tf
@@ -123,7 +123,7 @@ output "public_albs" {
   value = {
     delta      = module.public_albs.delta
     api        = module.public_albs.delta_api
-    keycloak   = module.public_albs.keycloak
+    auth       = module.public_albs.auth
     cpm        = module.public_albs.cpm
     jaspersoft = module.public_albs.jaspersoft
   }


### PR DESCRIPTION
Moved the auth alb listener to common infrastructure from delta since both auth service and keycloak will need to use it now

Created ECR repo and subnets for auth service.