### PR TITLE
DT-451: update Jaspersoft Tomcat version and docs

### DIFF
--- a/terraform/modules/jaspersoft/README.md
+++ b/terraform/modules/jaspersoft/README.md
@@ -103,9 +103,9 @@ aws s3 cp js-7.8.1_hotfixed_2022-04-15.zip s3://dluhc-jaspersoft-bin
 
 ## Updating Tomcat
 
-Change `TOMCAT_VERSION` to the updated version.
+Change `TOMCAT_VERSION` in `terraform/modules/jaspersoft/setup_script.sh` to the new version. Deployment will cause downtime as there is only one jaspersoft server per environment, but only for reports and only for a short time. 
 
-Run as root (`sudo su`)
+Alternatively, you can update the tomcat version manually. Run the following as root (`sudo su` to switch) with the desired value for TOMCAT_VERSION.
 
 ```sh
 # cd into the Tomcat folder

--- a/terraform/modules/jaspersoft/setup_script.sh
+++ b/terraform/modules/jaspersoft/setup_script.sh
@@ -2,7 +2,7 @@
 
 set -exuo pipefail
 
-export TOMCAT_VERSION=9.0.75
+export TOMCAT_VERSION=9.0.76
 
 # Let the instance finish booting
 sleep 5


### PR DESCRIPTION
Prod updated to 9.0.76 manually but there isn't a need to do it manually is there? I thought this was only from before we had a separate DB so we couldn't recycle the server. I'm tempted to delete the manual tomcat update instructions