### PR TITLE
DT-294 Scripted metrics from MarkLogic

### DIFF
--- a/terraform/modules/marklogic/app_logs.tf
+++ b/terraform/modules/marklogic/app_logs.tf
@@ -25,7 +25,8 @@ module "marklogic_log_group" {
       "${local.app_log_group_base_name}-crash",
       "${local.app_log_group_base_name}-error",
       local.taskserver_error_log_group_name,
-      "${local.app_log_group_base_name}-taskserver-request"
+      "${local.app_log_group_base_name}-taskserver-request",
+      local.metrics_log_group_name,
     ]
   )
 }

--- a/terraform/modules/marklogic/scripted_metrics.tf
+++ b/terraform/modules/marklogic/scripted_metrics.tf
@@ -1,0 +1,80 @@
+# MarkLogic doesn't have a native way of reporting metrics to CloudWatch.
+# We run an XQuery script (scripts/metrics-json.xqy) on the main MarkLogic node
+# every five minutes, send the results to CloudWatch logs and then use a metric filter to extract numeric values.
+
+locals {
+  metrics_log_group_name = "${local.app_log_group_base_name}-metrics"
+  metrics_cron_script = templatefile("${path.module}/scripts/metrics-cron.sh", {
+    LOG_GROUP_NAME = local.metrics_log_group_name
+    ENVIRONMENT    = var.environment
+    AWS_REGION     = data.aws_region.current.name
+  })
+}
+
+resource "aws_s3_object" "metrics_cron_script" {
+  content = local.metrics_cron_script
+  etag    = md5(local.metrics_cron_script)
+  bucket  = module.config_files_bucket.bucket
+  key     = "metrics-cron.sh"
+}
+
+resource "aws_s3_object" "metrics_xqy_script" {
+  source = "${path.module}/scripts/metrics-json.xqy"
+  etag   = filemd5("${path.module}/scripts/metrics-json.xqy")
+  bucket = module.config_files_bucket.bucket
+  key    = "metrics-json.xqy"
+}
+
+resource "aws_ssm_association" "setup_metrics_cron" {
+  name             = aws_ssm_document.setup_metrics_cron.name
+  association_name = "MarkLogic-MetricsSetup-${var.environment}"
+  parameters = {
+    ShellScriptLocation  = "s3://${aws_s3_object.metrics_cron_script.bucket}/${aws_s3_object.metrics_cron_script.key}"
+    XQueryScriptLocation = "s3://${aws_s3_object.metrics_xqy_script.bucket}/${aws_s3_object.metrics_xqy_script.key}"
+  }
+
+  targets {
+    key    = "tag:marklogic:stack:name"
+    values = [local.stack_name]
+  }
+
+  targets {
+    key    = "tag:Name"
+    values = [var.host_names[0]]
+  }
+
+  depends_on = [module.marklogic_log_group]
+  lifecycle {
+    replace_triggered_by = [
+      aws_ssm_document.setup_metrics_cron.content,
+      aws_s3_object.metrics_cron_script.etag,
+      aws_s3_object.metrics_xqy_script.etag,
+    ]
+  }
+}
+
+resource "aws_ssm_document" "setup_metrics_cron" {
+  name            = "MarkLogic-ConfigureMetricsCron-${var.environment}"
+  document_format = "YAML"
+  document_type   = "Command"
+
+  content = file("${path.module}/templates/metrics_config_ssm_doc.yml")
+}
+
+resource "aws_cloudwatch_log_metric_filter" "cron_metrics_filter" {
+  name           = "${var.environment}-marklogic-scipted-metrics"
+  log_group_name = local.metrics_log_group_name
+  pattern        = "{ $.value >= 0 }"
+
+  metric_transformation {
+    name      = "scripted-metrics"
+    namespace = "${var.environment}/MarkLogic"
+    value     = "$.value"
+    unit      = "None"
+    dimensions = {
+      "metric" : "$.metric"
+    }
+  }
+
+  depends_on = [module.marklogic_log_group]
+}

--- a/terraform/modules/marklogic/scripts/metrics-cron.sh
+++ b/terraform/modules/marklogic/scripts/metrics-cron.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+set -euo pipefail
+
+echo "Starting metrics run at $(date --iso-8601=seconds)"
+
+TOKEN=$(curl -sS -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
+INSTANCE_ID=$(curl -sS -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/instance-id)
+
+echo "Instance id $${INSTANCE_ID}"
+
+ML_USER_PASS=$(aws secretsmanager get-secret-value --secret-id ml-admin-user-${ENVIRONMENT} --region ${AWS_REGION} --query SecretString --output text)
+ML_USER=$(echo "$ML_USER_PASS" | jq -r '.username')
+ML_PASS=$(echo "$ML_USER_PASS" | jq -r '.password')
+
+echo "Creating log stream"
+aws logs create-log-stream --region ${AWS_REGION} --log-group-name ${LOG_GROUP_NAME} --log-stream-name $${INSTANCE_ID} || echo "Ignoring error, assuming log stream already exists"
+
+response=$(cat <(echo "xquery=") /metrics-cron/metrics-json.xqy | curl -sS --fail --anyauth --user "$ML_USER":"$ML_PASS" -X POST -d @- \
+                -H "Content-type: application/x-www-form-urlencoded" \
+                -H "Accept: */*" \
+                http://localhost:8002/v1/eval)
+
+# ML always returns "multipart/mixed" content type, we find the line with the output we want in
+json=$(echo "$response" | tr -d '\r' | grep "OUTPUT_JSON:" | cut -c13-)
+
+if [ -z "$json" ]; then
+  echo "JSON output not found in response"
+  echo "$response"
+  exit 1
+fi
+
+log_message=$(echo "$json" | jq -c '.[]' | jq -cR '[.,inputs] | map({"timestamp": (now * 1000 | floor), "message": .})')
+
+echo "Putting log event to ${LOG_GROUP_NAME}:$${INSTANCE_ID} $${log_message}"
+
+aws logs put-log-events --region ${AWS_REGION} --log-group-name ${LOG_GROUP_NAME} --log-stream-name $${INSTANCE_ID} --log-events "$log_message"
+
+echo "Done"

--- a/terraform/modules/marklogic/scripts/metrics-cron.sh
+++ b/terraform/modules/marklogic/scripts/metrics-cron.sh
@@ -14,8 +14,11 @@ ML_USER_PASS=$(aws secretsmanager get-secret-value --secret-id ml-admin-user-${E
 ML_USER=$(echo "$ML_USER_PASS" | jq -r '.username')
 ML_PASS=$(echo "$ML_USER_PASS" | jq -r '.password')
 
-echo "Creating log stream"
-aws logs create-log-stream --region ${AWS_REGION} --log-group-name ${LOG_GROUP_NAME} --log-stream-name $${INSTANCE_ID} || echo "Ignoring error, assuming log stream already exists"
+if [ "$#" -eq 1 ] && [ "$1" = "create-log-stream" ]; then
+  echo "Creating log stream ${LOG_GROUP_NAME}:$${INSTANCE_ID}"
+  aws logs create-log-stream --region ${AWS_REGION} --log-group-name ${LOG_GROUP_NAME} --log-stream-name $${INSTANCE_ID} || echo "Ignoring error, assuming log stream already exists"
+  exit 0
+fi
 
 response=$(cat <(echo "xquery=") /metrics-cron/metrics-json.xqy | curl -sS --fail --anyauth --user "$ML_USER":"$ML_PASS" -X POST -d @- \
                 -H "Content-type: application/x-www-form-urlencoded" \

--- a/terraform/modules/marklogic/scripts/metrics-json.xqy
+++ b/terraform/modules/marklogic/scripts/metrics-json.xqy
@@ -1,0 +1,70 @@
+xquery version "1.0-ml";
+
+declare namespace hs = "http://marklogic.com/xdmp/status/host";
+declare namespace ss = "http://marklogic.com/xdmp/status/server";
+declare namespace forest = "http://marklogic.com/xdmp/status/forest";
+declare namespace dluhc = "http://levellingup.gov.uk";
+
+declare %private function dluhc:metric($metric as xs:string, $value as item()) as map:map {
+  map:new((
+    map:entry("metric", $metric),
+    map:entry("value", $value)
+  ))
+};
+
+declare %private function dluhc:database-document-count($database-name as xs:string) as xs:long {
+  let $database := xdmp:database($database-name)
+  let $forest-ids := xdmp:database-forests($database)
+  let $forest-stats := for $forest-id in $forest-ids
+    let $forest-counts := xdmp:forest-counts($forest-id, ("document-count"))
+    order by $forest-counts/forest:forest-name/text()
+    return $forest-counts
+  return fn:sum(xs:int($forest-stats/forest:document-count))
+};
+
+declare %private function dluhc:security-summary() as map:map* {
+  xdmp:invoke-function(
+    function() {
+      (
+        dluhc:metric("sec-num-users", fn:count(//sec:user)),
+        dluhc:metric("sec-num-roles", fn:count(//sec:role))
+      )
+    },
+    <options xmlns="xdmp:eval">
+      <database>{xdmp:security-database()}</database>
+    </options>
+  )
+};
+
+declare %private function dluhc:payments-summary() as map:map* {
+  xdmp:invoke-function(
+    function() {
+      (
+        dluhc:metric("cpm-total-payments", fn:count(fn:collection("payment"))),
+        dluhc:metric("cpm-total-transactions", fn:count(fn:collection("transactions")))
+      )
+    },
+    <options xmlns="xdmp:eval">
+      <database>{xdmp:database("payments-content")}</database>
+    </options>
+  )
+};
+
+declare %private function dluhc:task-server-summary() as map:map* {
+  let $task-server-statuses := for $host as xs:unsignedLong in xdmp:hosts()
+    let $task-server-id := xdmp:host-status($host)//hs:task-server-id
+    return xdmp:server-status($host, $task-server-id)
+  return (
+    dluhc:metric("task-server-host-max-queue-size", fn:max($task-server-statuses//ss:queue-size)),
+    dluhc:metric("task-server-total-queue-size", fn:sum($task-server-statuses//ss:queue-size)),
+    dluhc:metric("task-server-currently-processing", fn:count($task-server-statuses//ss:request-statuses/ss:request-status))
+  )
+};
+
+"OUTPUT_JSON:" || xdmp:to-json((
+  for $d in ("delta-content", "payments-content", "Security")
+    return dluhc:metric($d || "-doc-count", dluhc:database-document-count($d)),
+  dluhc:security-summary(),
+  dluhc:payments-summary(),
+  dluhc:task-server-summary()
+))

--- a/terraform/modules/marklogic/templates/metrics_config_ssm_doc.yml
+++ b/terraform/modules/marklogic/templates/metrics_config_ssm_doc.yml
@@ -16,4 +16,5 @@ mainSteps:
         - "aws s3 cp --region eu-west-1 {{ShellScriptLocation}} /metrics-cron/metrics-cron.sh"
         - "chmod +x /metrics-cron/metrics-cron.sh"
         - "aws s3 cp --region eu-west-1 {{XQueryScriptLocation}} /metrics-cron/metrics-json.xqy"
+        - "/metrics-cron/metrics-cron.sh create-log-stream"
         - "echo '*/5 * * * * root OUTPUT=`/metrics-cron/metrics-cron.sh 2>&1` || echo $OUTPUT' > /etc/cron.d/ml-metrics"

--- a/terraform/modules/marklogic/templates/metrics_config_ssm_doc.yml
+++ b/terraform/modules/marklogic/templates/metrics_config_ssm_doc.yml
@@ -1,0 +1,19 @@
+---
+schemaVersion: "2.2"
+description: Configure metrics cron job
+parameters:
+  ShellScriptLocation:
+    type: String
+  XQueryScriptLocation:
+    type: String
+mainSteps:
+  - action: aws:runShellScript
+    name: startCloudwatchAgent
+    inputs:
+      timeoutSeconds: '120'
+      runCommand:
+        - "mkdir -p /metrics-cron"
+        - "aws s3 cp --region eu-west-1 {{ShellScriptLocation}} /metrics-cron/metrics-cron.sh"
+        - "chmod +x /metrics-cron/metrics-cron.sh"
+        - "aws s3 cp --region eu-west-1 {{XQueryScriptLocation}} /metrics-cron/metrics-json.xqy"
+        - "echo '*/5 * * * * root OUTPUT=`/metrics-cron/metrics-cron.sh 2>&1` || echo $OUTPUT' > /etc/cron.d/ml-metrics"


### PR DESCRIPTION
* Systems Manager to set up a cron job on the master MarkLogic node only (x.x.12.x)
* This posts an XQuery script to be evaluated which gathers metrics and returns them as JSON, e.g.
  ```json
  {"metric": "task-server-total-queue-size", "value": 20}
  ```
* The cron script gets them into a format CloudWatch expects and then does put-log-events via the CLI
* A metric filter turns those into CloudWatch metrics so we can graph + alarm on them (though I haven't done that yet)

Other options would be putting metric data directly, or sending embedded metric format logs to the CloudWatch agent, but this seemed simplest and works OK.