### PR TITLE
DT-176 CloudTrail send to CloudWatch

### DIFF
--- a/terraform/modules/cloudtrail/logging_kms_policy.json
+++ b/terraform/modules/cloudtrail/logging_kms_policy.json
@@ -1,0 +1,51 @@
+{
+  "Version": "2012-10-17",
+  "Id": "key-default-1",
+  "Statement": [
+    {
+      "Sid": "Enable IAM User Permissions",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::${account_id}:root"
+      },
+      "Action": "kms:*",
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "logs.${region}.amazonaws.com"
+      },
+      "Action": [
+        "kms:Encrypt*",
+        "kms:Decrypt*",
+        "kms:ReEncrypt*",
+        "kms:GenerateDataKey*",
+        "kms:Describe*"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "ArnLike": {
+          "kms:EncryptionContext:aws:logs:arn": ${jsonencode([for log_group_name in log_group_names : "arn:aws:logs:${region}:${account_id}:log-group:${log_group_name}"])}
+        }
+      }
+    },
+    {
+      "Sid": "Allow CloudTrail to encrypt logs",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "cloudtrail.amazonaws.com"
+      },
+      "Action": "kms:GenerateDataKey*",
+      "Resource": "*",
+      "Condition": {
+        "StringEquals": {
+          "aws:SourceArn": "arn:aws:cloudtrail:${region}:${account_id}:trail/${trail_name}"
+        },
+        "StringLike": {
+          "kms:EncryptionContext:aws:cloudtrail:arn": "arn:aws:cloudtrail:*:${account_id}:trail/*"
+        }
+      }
+    }
+  ]
+}

--- a/terraform/modules/cloudtrail/main.tf
+++ b/terraform/modules/cloudtrail/main.tf
@@ -1,0 +1,188 @@
+# CloudTrail logging to S3 and CloudWatch
+
+variable "environment" {
+  type = string
+}
+
+variable "cloudwatch_log_expiration_days" {
+  type = number
+}
+
+variable "s3_log_expiration_days" {
+  type = number
+}
+
+variable "include_data_events_for_bucket_names" {
+  type = list(string)
+}
+
+data "aws_caller_identity" "current" {}
+
+data "aws_region" "current" {}
+
+locals {
+  trail_name     = "dluhc-${var.environment}"
+  log_group_name = "cloudtrail-${var.environment}"
+  s3_prefix      = "dluhc-${var.environment}"
+  data_event_s3_arns = [
+    for name in concat(var.include_data_events_for_bucket_names) : "arn:aws:s3:::${name}/"
+  ]
+}
+
+resource "aws_cloudtrail" "main" {
+  name                          = local.trail_name
+  s3_bucket_name                = module.s3_bucket.bucket
+  s3_key_prefix                 = local.s3_prefix
+  include_global_service_events = true
+  kms_key_id                    = aws_kms_key.main.arn
+  cloud_watch_logs_group_arn    = "${aws_cloudwatch_log_group.main.arn}:*"
+  cloud_watch_logs_role_arn     = aws_iam_role.cloudtrail.arn
+  is_multi_region_trail         = true
+  enable_log_file_validation    = true
+
+  event_selector {
+    read_write_type           = "All"
+    include_management_events = true
+
+    data_resource {
+      type   = "AWS::S3::Object"
+      values = local.data_event_s3_arns
+    }
+  }
+}
+
+resource "aws_kms_key" "main" {
+  enable_key_rotation = true
+  description         = "dluhc-delta-cloudtrail-${var.environment}"
+  policy = templatefile("${path.module}/logging_kms_policy.json", {
+    account_id      = data.aws_caller_identity.current.account_id
+    region          = data.aws_region.current.name
+    log_group_names = [local.log_group_name]
+    trail_name      = local.trail_name
+  })
+}
+
+resource "aws_kms_alias" "main" {
+  name          = "alias/dluhc-delta-cloudtrail-${var.environment}"
+  target_key_id = aws_kms_key.main.key_id
+}
+
+module "s3_bucket" {
+  source = "../s3_bucket"
+
+  access_log_bucket_name             = "dluhc-delta-cloudtrail-${var.environment}-access-logs"
+  bucket_name                        = "dluhc-delta-cloudtrail-${var.environment}"
+  access_s3_log_expiration_days      = var.s3_log_expiration_days
+  policy                             = data.aws_iam_policy_document.bucket_policy.json
+  kms_key_arn                        = aws_kms_key.main.arn
+  noncurrent_version_expiration_days = null
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "expire" {
+  bucket = module.s3_bucket.bucket
+
+  rule {
+    id = "expiration"
+    filter {}
+    expiration {
+      days = var.s3_log_expiration_days
+    }
+    status = "Enabled"
+  }
+}
+
+data "aws_iam_policy_document" "bucket_policy" {
+  statement {
+    sid    = "AWSCloudTrailAclCheck"
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["cloudtrail.amazonaws.com"]
+    }
+
+    actions   = ["s3:GetBucketAcl"]
+    resources = [module.s3_bucket.bucket_arn]
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceArn"
+      values = [
+        "arn:aws:cloudtrail:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:trail/${local.trail_name}"
+      ]
+    }
+  }
+
+  statement {
+    sid    = "AWSCloudTrailWrite"
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["cloudtrail.amazonaws.com"]
+    }
+
+    actions   = ["s3:PutObject"]
+    resources = ["${module.s3_bucket.bucket_arn}/*"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "s3:x-amz-acl"
+      values   = ["bucket-owner-full-control"]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceArn"
+      values = [
+        "arn:aws:cloudtrail:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:trail/${local.trail_name}"
+      ]
+    }
+  }
+}
+
+resource "aws_cloudwatch_log_group" "main" {
+  name              = local.log_group_name
+  retention_in_days = var.cloudwatch_log_expiration_days
+  kms_key_id        = aws_kms_key.main.arn
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "aws_iam_role" "cloudtrail" {
+  name = "cloudtrail-to-cloudwatch-${var.environment}"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Sid    = ""
+        Principal = {
+          Service = "cloudtrail.amazonaws.com"
+        }
+      },
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "cloudtrail" {
+  name   = "cloudtrail-to-cloudwatch-${var.environment}"
+  role   = aws_iam_role.cloudtrail.id
+  policy = data.aws_iam_policy_document.cloudtrail_to_cloudwatch.json
+}
+
+# tfsec:ignore:aws-iam-no-policy-wildcards
+data "aws_iam_policy_document" "cloudtrail_to_cloudwatch" {
+  version = "2012-10-17"
+  statement {
+    effect = "Allow"
+    actions = [
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+      "logs:DescribeLogStreams",
+    ]
+    resources = ["${aws_cloudwatch_log_group.main.arn}:*"]
+  }
+}

--- a/terraform/modules/encrypted_log_groups/main.tf
+++ b/terraform/modules/encrypted_log_groups/main.tf
@@ -3,6 +3,11 @@ data "aws_region" "current" {}
 
 variable "kms_key_alias_name" {
   type = string
+
+  validation {
+    condition     = !startswith(var.kms_key_alias_name, "alias/")
+    error_message = "Only include the name after alias/"
+  }
 }
 
 variable "log_group_names" {
@@ -19,6 +24,10 @@ output "log_group_names" {
 
 output "log_group_arns" {
   value = [for lg in aws_cloudwatch_log_group.logs : lg.arn]
+}
+
+output "kms_key_arn" {
+  value = aws_kms_key.logs.arn
 }
 
 resource "aws_kms_key" "logs" {

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -380,6 +380,14 @@ module "guardduty" {
   aws_security_topic_arn = module.notifications.security_sns_topic_arn
 }
 
+module "cloudtrail" {
+  source                               = "../modules/cloudtrail"
+  environment                          = local.environment
+  include_data_events_for_bucket_names = ["data-collection-service-tfstate-production"]
+  cloudwatch_log_expiration_days       = local.cloudwatch_log_expiration_days
+  s3_log_expiration_days               = local.s3_log_expiration_days
+}
+
 module "iam_roles" {
   source = "../modules/iam_roles"
 

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -399,6 +399,14 @@ module "guardduty" {
   aws_security_topic_arn = module.notifications.security_sns_topic_arn
 }
 
+module "cloudtrail" {
+  source                               = "../modules/cloudtrail"
+  environment                          = local.environment
+  include_data_events_for_bucket_names = ["data-collection-service-tfstate-dev"]
+  cloudwatch_log_expiration_days       = local.cloudwatch_log_expiration_days
+  s3_log_expiration_days               = local.s3_log_expiration_days
+}
+
 moved {
   from = aws_lb_listener.auth
   to   = module.public_albs.aws_lb_listener.auth


### PR DESCRIPTION
This is set up in staging. The permissions are a bit fiddly, but the CloudTrail itself is fairly simple, sending logs to S3 and CloudWatch.

I've left the expiration time as the default for that environment, so two years for prod. I don't imagine there will be enough data to build up significant cost, but I'll keep an eye on it once it's deployed and we can reduce the retention if required since there's an organisation level trail anyway.

I haven't set up any alarms based on it.
