### PR TITLE
DT-518 Make auth WAF IP restriction keycloak-only

### DIFF
--- a/terraform/modules/cloudfront_distributions/keycloak_function.tf
+++ b/terraform/modules/cloudfront_distributions/keycloak_function.tf
@@ -7,7 +7,8 @@ resource "aws_cloudfront_function" "keycloak_request" {
   function handler(event) {
     var request = event.request;
 
-    request.uri = request.uri.replace(/^\/auth\//,'/keycloak/');
+    // Note that this runs after the WAF so the IP restriction there should apply to all paths this affects
+    request.uri = request.uri.replace(/^\/auth\/realms\/delta\//,'/keycloak/realms/delta/');
     request.uri = request.uri.replace(/^\/realms\/delta\//,'/keycloak/realms/delta/')
 
     return request;

--- a/terraform/modules/cloudfront_distributions/main.tf
+++ b/terraform/modules/cloudfront_distributions/main.tf
@@ -45,14 +45,33 @@ module "cpm_waf" {
   security_sns_topic_global_arn  = var.security_sns_topic_global_arn
 }
 
-module "api_auth_waf" {
+module "api_waf" {
   source            = "../waf"
   prefix            = "${var.environment}-delta-api-"
   log_group_suffix  = "delta-api-${var.environment}"
   per_ip_rate_limit = var.waf_per_ip_rate_limit
   # XSS not issue for API
-  excluded_rules                 = ["CrossSiteScripting_BODY", "CrossSiteScripting_COOKIE", "CrossSiteScripting_QUERYARGUMENTS", "CrossSiteScripting_URIPATH"]
+  excluded_rules = ["CrossSiteScripting_BODY", "CrossSiteScripting_COOKIE", "CrossSiteScripting_QUERYARGUMENTS", "CrossSiteScripting_URIPATH"]
   ip_allowlist                   = var.api.ip_allowlist
+  cloudwatch_log_expiration_days = var.waf_cloudwatch_log_expiration_days
+  alarms_sns_topic_global_arn    = var.alarms_sns_topic_global_arn
+  security_sns_topic_global_arn  = var.security_sns_topic_global_arn
+}
+
+moved {
+  //noinspection HILUnresolvedReference
+  from = module.api_auth_waf
+  to   = module.api_waf
+}
+
+module "auth_waf" {
+  source                         = "../waf"
+  prefix                         = "${var.environment}-auth-"
+  log_group_suffix               = "auth-${var.environment}"
+  per_ip_rate_limit              = var.auth_waf_per_ip_rate_limit
+  excluded_rules                 = ["CrossSiteScripting_BODY"]
+  ip_allowlist                   = var.api.ip_allowlist
+  ip_allowlist_uri_path_regex    = "^/keycloak/"
   cloudwatch_log_expiration_days = var.waf_cloudwatch_log_expiration_days
   alarms_sns_topic_global_arn    = var.alarms_sns_topic_global_arn
   security_sns_topic_global_arn  = var.security_sns_topic_global_arn
@@ -79,7 +98,7 @@ module "api_cloudfront" {
   prefix                         = "delta-api-${var.environment}-"
   access_logs_bucket_domain_name = module.access_logs_bucket.bucket_domain_name
   access_logs_prefix             = "delta-api"
-  waf_acl_arn                    = module.api_auth_waf.acl_arn
+  waf_acl_arn                    = module.api_waf.acl_arn
   cloudfront_key                 = var.api.alb.cloudfront_key
   origin_domain                  = var.api.alb.dns_name
   cloudfront_domain              = var.api.domain
@@ -92,12 +111,12 @@ module "api_cloudfront" {
 
 }
 
-module "keycloak_cloudfront" {
+module "auth_cloudfront" {
   source                         = "../cloudfront_distribution"
   prefix                         = "keycloak-${var.environment}-"
   access_logs_bucket_domain_name = module.access_logs_bucket.bucket_domain_name
   access_logs_prefix             = "keycloak"
-  waf_acl_arn                    = module.api_auth_waf.acl_arn
+  waf_acl_arn                    = module.auth_waf.acl_arn
   cloudfront_key                 = var.keycloak.alb.cloudfront_key
   origin_domain                  = var.keycloak.alb.dns_name
   cloudfront_domain              = var.keycloak.domain
@@ -106,9 +125,13 @@ module "keycloak_cloudfront" {
   apply_aws_shield               = var.apply_aws_shield
   function_associations          = [{ event_type = "viewer-request", function_arn = aws_cloudfront_function.keycloak_request.arn }]
   wait_for_deployment            = var.wait_for_deployment
-
 }
 
+moved {
+  //noinspection HILUnresolvedReference
+  from = module.keycloak_cloudfront
+  to   = module.auth_cloudfront
+}
 
 module "cpm_cloudfront" {
   source                         = "../cloudfront_distribution"

--- a/terraform/modules/cloudfront_distributions/main.tf
+++ b/terraform/modules/cloudfront_distributions/main.tf
@@ -51,7 +51,7 @@ module "api_waf" {
   log_group_suffix  = "delta-api-${var.environment}"
   per_ip_rate_limit = var.waf_per_ip_rate_limit
   # XSS not issue for API
-  excluded_rules = ["CrossSiteScripting_BODY", "CrossSiteScripting_COOKIE", "CrossSiteScripting_QUERYARGUMENTS", "CrossSiteScripting_URIPATH"]
+  excluded_rules                 = ["CrossSiteScripting_BODY", "CrossSiteScripting_COOKIE", "CrossSiteScripting_QUERYARGUMENTS", "CrossSiteScripting_URIPATH"]
   ip_allowlist                   = var.api.ip_allowlist
   cloudwatch_log_expiration_days = var.waf_cloudwatch_log_expiration_days
   alarms_sns_topic_global_arn    = var.alarms_sns_topic_global_arn
@@ -71,7 +71,7 @@ module "auth_waf" {
   per_ip_rate_limit              = var.auth_waf_per_ip_rate_limit
   excluded_rules                 = ["CrossSiteScripting_BODY"]
   ip_allowlist                   = var.api.ip_allowlist
-  ip_allowlist_uri_path_regex    = "^/keycloak/"
+  ip_allowlist_uri_path_regex    = ["^/keycloak/", "/realms/delta/"]
   cloudwatch_log_expiration_days = var.waf_cloudwatch_log_expiration_days
   alarms_sns_topic_global_arn    = var.alarms_sns_topic_global_arn
   security_sns_topic_global_arn  = var.security_sns_topic_global_arn

--- a/terraform/modules/cloudfront_distributions/output.tf
+++ b/terraform/modules/cloudfront_distributions/output.tf
@@ -14,7 +14,7 @@ output "required_dns_records" {
       {
         record_name  = "auth.delta.${base_domain}."
         record_type  = "CNAME"
-        record_value = "${module.keycloak_cloudfront.cloudfront_domain_name}."
+        record_value = "${module.auth_cloudfront.cloudfront_domain_name}."
       },
       {
         record_name  = "cpm.${base_domain}."
@@ -46,12 +46,12 @@ output "api_cloudfront_distribution_id" {
   value = module.api_cloudfront.cloudfront_distribution_id
 }
 
-output "keycloak_cloudfront_domain" {
-  value = module.keycloak_cloudfront.cloudfront_domain_name
+output "auth_cloudfront_domain" {
+  value = module.auth_cloudfront.cloudfront_domain_name
 }
 
-output "keycloak_cloudfront_distribution_id" {
-  value = module.keycloak_cloudfront.cloudfront_distribution_id
+output "auth_cloudfront_distribution_id" {
+  value = module.auth_cloudfront.cloudfront_distribution_id
 }
 
 output "cpm_cloudfront_domain" {

--- a/terraform/modules/cloudfront_distributions/variables.tf
+++ b/terraform/modules/cloudfront_distributions/variables.tf
@@ -6,6 +6,12 @@ variable "environment" {
   type = string
 }
 
+variable "auth_waf_per_ip_rate_limit" {
+  type        = number
+  default     = 200
+  description = "The per-IP rate limit enforced by AWS WAF in requests per five minutes for the auth service"
+}
+
 variable "waf_per_ip_rate_limit" {
   type        = number
   default     = 1000

--- a/terraform/modules/public_albs/auth_listener.tf
+++ b/terraform/modules/public_albs/auth_listener.tf
@@ -10,8 +10,8 @@ resource "aws_lb_listener" "auth" {
     type = "fixed-response"
     fixed_response {
       content_type = "text/plain"
-      message_body = "Unknown route"
-      status_code  = "404"
+      message_body = "Invalid CloudFront key"
+      status_code  = "403"
     }
   }
 }

--- a/terraform/modules/waf/main.tf
+++ b/terraform/modules/waf/main.tf
@@ -26,6 +26,7 @@ locals {
   all_routes_ip_allowlist_enabled    = var.ip_allowlist != null && var.ip_allowlist_uri_path_regex == null
   path_specific_ip_allowlist_enabled = var.ip_allowlist != null && var.ip_allowlist_uri_path_regex != null
   ip_reputation_enabled              = !local.all_routes_ip_allowlist_enabled
+  // For the "for_each" argument of dynamic blocks, a list of one item "[{}]" means on, empty list "[]" is off
   all_routes_ip_allowlist_foreach    = local.all_routes_ip_allowlist_enabled ? [{}] : []
   path_specific_ip_allowlist_foreach = local.path_specific_ip_allowlist_enabled ? [{}] : []
   ip_reputation_foreach              = local.ip_reputation_enabled ? [{}] : []
@@ -207,6 +208,7 @@ resource "aws_wafv2_web_acl" "waf_acl" {
   dynamic "rule" {
     for_each = local.path_specific_ip_allowlist_foreach
     content {
+      // Should never be on at the same time as the "ip-allowlist" rule above
       name     = "ip-allowlist-path"
       priority = 50 + local.priority_base
       action {
@@ -218,6 +220,7 @@ resource "aws_wafv2_web_acl" "waf_acl" {
         }
       }
 
+      // Block requests that match ip_restricted_paths unless they are on the IP allowlist
       statement {
         and_statement {
           statement {

--- a/terraform/modules/waf/main.tf
+++ b/terraform/modules/waf/main.tf
@@ -23,8 +23,13 @@ locals {
     ip_reputation       = replace("${var.prefix}cloudfront-waf-ip-reputation", "-", "")
     ip_allowlist        = replace("${var.prefix}cloudfront-waf-ip-allowlist", "-", "")
   }
-  ip_reputation_enabled       = var.ip_allowlist == null ? [{}] : []
-  login_ip_rate_limit_enabled = var.login_ip_rate_limit_enabled ? [{}] : []
+  all_routes_ip_allowlist_enabled    = var.ip_allowlist != null && var.ip_allowlist_uri_path_regex == null
+  path_specific_ip_allowlist_enabled = var.ip_allowlist != null && var.ip_allowlist_uri_path_regex != null
+  ip_reputation_enabled              = !local.all_routes_ip_allowlist_enabled
+  all_routes_ip_allowlist_foreach    = local.all_routes_ip_allowlist_enabled ? [{}] : []
+  path_specific_ip_allowlist_foreach = local.path_specific_ip_allowlist_enabled ? [{}] : []
+  ip_reputation_foreach              = local.ip_reputation_enabled ? [{}] : []
+  login_ip_rate_limit_foreach        = var.login_ip_rate_limit_enabled ? [{}] : []
 }
 
 output "acl_arn" {
@@ -143,7 +148,7 @@ resource "aws_wafv2_web_acl" "waf_acl" {
 
   # Either use the AWS managed IP reputation list, or an explicit allowlist
   dynamic "rule" {
-    for_each = local.ip_reputation_enabled
+    for_each = local.ip_reputation_foreach
     content {
       name     = "aws-ip-reputation"
       priority = 40 + local.priority_base
@@ -168,10 +173,10 @@ resource "aws_wafv2_web_acl" "waf_acl" {
   }
 
   dynamic "rule" {
-    for_each = aws_wafv2_ip_set.main
+    for_each = local.all_routes_ip_allowlist_foreach
     content {
       name     = "ip-allowlist"
-      priority = 40 + local.priority_base
+      priority = 50 + local.priority_base
       action {
         block {
           custom_response {
@@ -185,7 +190,7 @@ resource "aws_wafv2_web_acl" "waf_acl" {
         not_statement {
           statement {
             ip_set_reference_statement {
-              arn = rule.value.arn
+              arn = aws_wafv2_ip_set.main[0].arn
             }
           }
         }
@@ -200,10 +205,66 @@ resource "aws_wafv2_web_acl" "waf_acl" {
   }
 
   dynamic "rule" {
-    for_each = local.login_ip_rate_limit_enabled
+    for_each = local.path_specific_ip_allowlist_foreach
+    content {
+      name     = "ip-allowlist-path"
+      priority = 50 + local.priority_base
+      action {
+        block {
+          custom_response {
+            custom_response_body_key = "ip_error"
+            response_code            = 403
+          }
+        }
+      }
+
+      statement {
+        and_statement {
+          statement {
+            not_statement {
+              statement {
+                ip_set_reference_statement {
+                  arn = aws_wafv2_ip_set.main[0].arn
+                }
+              }
+            }
+          }
+          statement {
+            regex_match_statement {
+              regex_string = var.ip_allowlist_uri_path_regex
+              field_to_match {
+                uri_path {}
+              }
+              text_transformation {
+                priority = 0
+                type     = "URL_DECODE"
+              }
+              text_transformation {
+                priority = 1
+                type     = "NORMALIZE_PATH"
+              }
+              text_transformation {
+                priority = 2
+                type     = "LOWERCASE"
+              }
+            }
+          }
+        }
+      }
+
+      visibility_config {
+        cloudwatch_metrics_enabled = true
+        metric_name                = local.metric_names.ip_allowlist
+        sampled_requests_enabled   = true
+      }
+    }
+  }
+
+  dynamic "rule" {
+    for_each = local.login_ip_rate_limit_foreach
     content {
       name     = "login-ip-rate-limit"
-      priority = 50 + local.priority_base
+      priority = 70 + local.priority_base
 
       action {
         block {}

--- a/terraform/modules/waf/variables.tf
+++ b/terraform/modules/waf/variables.tf
@@ -14,7 +14,7 @@ variable "ip_allowlist" {
 }
 
 variable "ip_allowlist_uri_path_regex" {
-  type    = string
+  type    = list(string)
   default = null
 }
 

--- a/terraform/modules/waf/variables.tf
+++ b/terraform/modules/waf/variables.tf
@@ -13,6 +13,11 @@ variable "ip_allowlist" {
   default = null
 }
 
+variable "ip_allowlist_uri_path_regex" {
+  type    = string
+  default = null
+}
+
 variable "per_ip_rate_limit" {
   type        = number
   description = "Requests per five minutes"

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -247,7 +247,7 @@ module "cloudfront_alb_monitoring" {
     instance_metric_namespace  = null
   }
   keycloak = {
-    cloudfront_distribution_id = module.cloudfront_distributions.keycloak_cloudfront_distribution_id
+    cloudfront_distribution_id = module.cloudfront_distributions.auth_cloudfront_distribution_id
     alb_arn_suffix             = module.public_albs.auth.arn_suffix
     instance_metric_namespace  = null
   }

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -134,7 +134,7 @@ module "cloudfront_alb_monitoring" {
     instance_metric_namespace  = null
   }
   keycloak = {
-    cloudfront_distribution_id = module.cloudfront_distributions.keycloak_cloudfront_distribution_id
+    cloudfront_distribution_id = module.cloudfront_distributions.auth_cloudfront_distribution_id
     alb_arn_suffix             = module.public_albs.auth.arn_suffix
     instance_metric_namespace  = null
   }

--- a/terraform/test/main.tf
+++ b/terraform/test/main.tf
@@ -156,7 +156,7 @@ module "cloudfront_alb_monitoring" {
     instance_metric_namespace  = null
   }
   keycloak = {
-    cloudfront_distribution_id = module.cloudfront_distributions.keycloak_cloudfront_distribution_id
+    cloudfront_distribution_id = module.cloudfront_distributions.auth_cloudfront_distribution_id
     alb_arn_suffix             = module.public_albs.auth.arn_suffix
     instance_metric_namespace  = null
   }
@@ -188,6 +188,7 @@ module "cloudfront_distributions" {
   environment                              = local.environment
   base_domains                             = [var.primary_domain]
   waf_per_ip_rate_limit                    = 100000
+  auth_waf_per_ip_rate_limit               = 1000
   login_ip_rate_limit                      = 500
   apply_aws_shield                         = local.apply_aws_shield
   waf_cloudwatch_log_expiration_days       = local.cloudwatch_log_expiration_days


### PR DESCRIPTION
The auth service is now at the root of the auth domain, Keycloak is only at `/keycloak`. Apply the IP restriction to that path only. Also rename the CloudFront distribution within Terraform from "keycloak" to "auth", but not on CloudFront itself.

Edit: Turns out WAF happens before the rewriter lambda, will need to cover those paths too - done