### PR TITLE
Disable KMS encryption for access log target buckets

### DIFF
--- a/terraform/modules/marklogic/backup_buckets_new.tf
+++ b/terraform/modules/marklogic/backup_buckets_new.tf
@@ -1,3 +1,5 @@
+# MarkLogic ignores the default KMS settings, so we no longer use this,
+# but are keeping it for now just in case anything has ended up encrypted
 resource "aws_kms_key" "ml_backup_bucket_key" {
   enable_key_rotation = true
   description         = "ml-backups-${var.environment}"
@@ -15,7 +17,6 @@ module "daily_backup_bucket" {
 
   bucket_name                        = "dluhc-daily-ml-backup-${var.environment}"
   access_log_bucket_name             = "dluhc-daily-backup-access-logs-${var.environment}"
-  kms_key_arn                        = aws_kms_key.ml_backup_bucket_key.arn
   noncurrent_version_expiration_days = 5
   access_s3_log_expiration_days      = var.backup_s3_log_expiration_days
 }
@@ -27,7 +28,6 @@ module "weekly_backup_bucket" {
 
   bucket_name                        = "dluhc-weekly-ml-backup-${var.environment}"
   access_log_bucket_name             = "dluhc-weekly-ml-backup-access-logs-${var.environment}"
-  kms_key_arn                        = aws_kms_key.ml_backup_bucket_key.arn
   noncurrent_version_expiration_days = null # Specify our own lifecycle policy
   access_s3_log_expiration_days      = var.backup_s3_log_expiration_days
 }

--- a/terraform/modules/s3_bucket/main.tf
+++ b/terraform/modules/s3_bucket/main.tf
@@ -119,13 +119,14 @@ resource "aws_s3_bucket_logging" "main" {
   target_prefix = "log/"
 }
 
+# KMS encryption is not supported for logging target buckets
+# tfsec:ignore:aws-s3-encryption-customer-key
 resource "aws_s3_bucket_server_side_encryption_configuration" "log_bucket" {
   bucket = aws_s3_bucket.log_bucket.bucket
 
   rule {
     apply_server_side_encryption_by_default {
-      kms_master_key_id = var.kms_key_arn
-      sse_algorithm     = var.kms_key_arn == null ? "AES256" : "aws:kms"
+      sse_algorithm = "AES256"
     }
   }
 }


### PR DESCRIPTION
It's not supported: https://docs.aws.amazon.com/AmazonS3/latest/userguide/enable-server-access-logging.html