### PR TITLE
DT-335 Update geo-restriction for API and Auth service

### DIFF
--- a/terraform/modules/cloudfront_distributions/main.tf
+++ b/terraform/modules/cloudfront_distributions/main.tf
@@ -120,7 +120,7 @@ module "auth_cloudfront" {
   cloudfront_key                 = var.keycloak.alb.cloudfront_key
   origin_domain                  = var.keycloak.alb.dns_name
   cloudfront_domain              = var.keycloak.domain
-  is_ipv6_enabled                = var.keycloak.ip_allowlist == null
+  is_ipv6_enabled                = false
   geo_restriction_countries      = var.keycloak.geo_restriction_countries
   apply_aws_shield               = var.apply_aws_shield
   function_associations          = [{ event_type = "viewer-request", function_arn = aws_cloudfront_function.keycloak_request.arn }]

--- a/terraform/modules/cloudfront_distributions/variables.tf
+++ b/terraform/modules/cloudfront_distributions/variables.tf
@@ -88,8 +88,8 @@ variable "keycloak" {
       aliases             = list(string)
       acm_certificate_arn = string
     }))
-    geo_restriction_countries = optional(list(string))
-    ip_allowlist              = optional(list(string))
+    geo_restriction_countries  = optional(list(string))
+    keycloak_path_ip_allowlist = optional(list(string))
 
     server_error_rate_alarm_threshold_percent = optional(number)
     client_error_rate_alarm_threshold_percent = optional(number)

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -299,8 +299,8 @@ module "cloudfront_distributions" {
       acm_certificate_arn = module.communities_only_ssl_certs.cloudfront_certs["api"].arn
     }
     ip_allowlist = local.cloudfront_ip_allowlists.delta_api
-    # Home Connections claim their servers are in the UK, but they currently get geo-located to US
-    geo_restriction_countries = ["GB", "IE", "US"]
+    # Home Connections claim their servers are in the UK but their supplier is international so can be geolocated incorrectly
+    geo_restriction_countries = null
   }
   keycloak = {
     alb = module.public_albs.auth
@@ -309,8 +309,8 @@ module "cloudfront_distributions" {
       acm_certificate_arn = module.communities_only_ssl_certs.cloudfront_certs["keycloak"].arn
     }
     keycloak_path_ip_allowlist = local.cloudfront_ip_allowlists.delta_api
-    # Home Connections claim their servers are in the UK, but they currently get geo-located to US
-    geo_restriction_countries = ["GB", "IE", "US"]
+    # Home Connections claim their servers are in the UK but their supplier is international so can be geolocated incorrectly
+    geo_restriction_countries = null
   }
   cpm = {
     alb = module.public_albs.cpm

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -299,8 +299,8 @@ module "cloudfront_distributions" {
       acm_certificate_arn = module.communities_only_ssl_certs.cloudfront_certs["api"].arn
     }
     ip_allowlist = local.cloudfront_ip_allowlists.delta_api
-    # Home Connections claim their servers are in the UK but their supplier is international so can be geolocated incorrectly
-    geo_restriction_countries = null
+    # Home Connections claim their servers are in the UK, but they currently get geo-located to US
+    geo_restriction_countries = ["GB", "IE", "US"]
   }
   keycloak = {
     alb = module.public_albs.auth
@@ -308,9 +308,9 @@ module "cloudfront_distributions" {
       aliases             = ["auth.delta.${var.primary_domain}"]
       acm_certificate_arn = module.communities_only_ssl_certs.cloudfront_certs["keycloak"].arn
     }
-    ip_allowlist = local.cloudfront_ip_allowlists.delta_api
-    # Home Connections claim their servers are in the UK but their supplier is international so can be geolocated incorrectly
-    geo_restriction_countries = null
+    keycloak_path_ip_allowlist = local.cloudfront_ip_allowlists.delta_api
+    # Home Connections claim their servers are in the UK, but they currently get geo-located to US
+    geo_restriction_countries = ["GB", "IE", "US"]
   }
   cpm = {
     alb = module.public_albs.cpm

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -193,8 +193,8 @@ module "cloudfront_distributions" {
       aliases             = ["api.delta.${var.primary_domain}"]
       acm_certificate_arn = module.communities_only_ssl_certs.cloudfront_certs["api"].arn
     }
-    # Home Connections claim their servers are in the UK but their supplier is international so can be geolocated incorrectly
-    geo_restriction_countries = null
+    # Home Connections claim their servers are in the UK, but they currently get geo-located to US
+    geo_restriction_countries = ["GB", "IE", "US"]
   }
   keycloak = {
     alb = module.public_albs.auth
@@ -202,8 +202,8 @@ module "cloudfront_distributions" {
       aliases             = ["auth.delta.${var.primary_domain}"]
       acm_certificate_arn = module.communities_only_ssl_certs.cloudfront_certs["keycloak"].arn
     }
-    # Home Connections claim their servers are in the UK but their supplier is international so can be geolocated incorrectly
-    geo_restriction_countries = null
+    # Home Connections claim their servers are in the UK, but they currently get geo-located to US
+    geo_restriction_countries = ["GB", "IE", "US"]
   }
   cpm = {
     alb = module.public_albs.cpm


### PR DESCRIPTION
Having the geo-restriction completely disabled for the auth service isn't ideal, but it's currently open due to Home Connections non-UK IP.

Home Connection's IPs all come up as US currently https://www.maxmind.com/en/geoip2-precision-demo so I've added that to the list.

We'll need to co-ordinate with them to test it when we release this.