### PR TITLE
DT-227 Create S3 bucket for imported Datamart logs

### DIFF
--- a/terraform/production/datamart_imported_logs.tf
+++ b/terraform/production/datamart_imported_logs.tf
@@ -1,0 +1,52 @@
+# Logs imported from Datamart for retention
+
+# At time of writing our policy is to retain production logs for two years,
+# so this should be kept until March 2025, after which it can be deleted
+module "datamart_imported_logs_bucket" {
+  source = "../modules/s3_bucket"
+
+  bucket_name                   = "dluhc-datamart-imported-logs-production"
+  access_log_bucket_name        = "dluhc-datamart-imported-logs-production-access-logs"
+  access_s3_log_expiration_days = local.s3_log_expiration_days
+  policy                        = data.aws_iam_policy_document.allow_access_from_datamart.json
+  restrict_public_buckets       = false
+}
+
+locals {
+  datamart_account_id = "090682378586"
+}
+
+data "aws_iam_policy_document" "allow_access_from_datamart" {
+  statement {
+    principals {
+      type        = "AWS"
+      identifiers = [local.datamart_account_id]
+    }
+
+    actions = [
+      "s3:GetBucketLocation", "s3:GetEncryptionConfiguration", "s3:ListBucket", "s3:GetObject", "s3:DeleteObject"
+    ]
+
+    resources = [
+      module.datamart_imported_logs_bucket.bucket_arn,
+      "${module.datamart_imported_logs_bucket.bucket_arn}/*",
+    ]
+  }
+
+  statement {
+    principals {
+      type        = "AWS"
+      identifiers = [local.datamart_account_id]
+    }
+
+    actions = ["s3:PutObject"]
+
+    resources = ["${module.datamart_imported_logs_bucket.bucket_arn}/*"]
+
+    condition {
+      test     = "StringEquals"
+      values   = ["GLACIER"] # "Glacier Flexible Retrieval"
+      variable = "s3:x-amz-storage-class"
+    }
+  }
+}


### PR DESCRIPTION
Create a bucket and grant the Datamart AWS account access to it through the bucket policy, with the restriction that they can only PutObject straight to the GLACIER (Glacier Flexible Retrieval) storage class, e.g.

```sh
aws s3 cp a-file s3://dluhc-datamart-imported-logs-production/a-file --storage-class GLACIER
```

I've already applied this, so if we're happy with it we can give Digital Space the bucket name.