### PR TITLE
DT-547: Create marklogic metric alarms

### DIFF
--- a/terraform/modules/marklogic/monitoring_alarms.tf
+++ b/terraform/modules/marklogic/monitoring_alarms.tf
@@ -215,3 +215,98 @@ resource "aws_cloudwatch_metric_alarm" "swap_usage_high" {
 
   dimensions = {}
 }
+
+resource "aws_cloudwatch_metric_alarm" "time_since_payments_content_backup_high" {
+  alarm_name          = "marklogic-${var.environment}-time-since-payments-content-backup-high"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  metric_name         = "scripted-metrics"
+  namespace           = "${var.environment}/MarkLogic"
+  period              = 300
+  statistic           = "Maximum"
+  threshold           = 1800 //30 hours in minutes
+
+  alarm_description  = "Longer than expected since payments-content was backed up"
+  alarm_actions      = [var.alarms_sns_topic_arn]
+  ok_actions         = [var.alarms_sns_topic_arn]
+  treat_missing_data = "missing"
+  dimensions = {
+    "metric" = "payments-content-minutes-since-backup"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "time_since_delta_content_backup_high" {
+  alarm_name          = "marklogic-${var.environment}-time-since-delta-content-backup-high"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  metric_name         = "scripted-metrics"
+  namespace           = "${var.environment}/MarkLogic"
+  period              = 300
+  statistic           = "Maximum"
+  threshold           = 1800 //30 hours in minutes
+
+  alarm_description  = "Longer than expected since delta-content was backed up"
+  alarm_actions      = [var.alarms_sns_topic_arn]
+  ok_actions         = [var.alarms_sns_topic_arn]
+  treat_missing_data = "missing"
+  dimensions = {
+    "metric" = "delta-content-minutes-since-backup"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "time_since_payments_content_incremental_backup_high" {
+  alarm_name          = "marklogic-${var.environment}-time-since-payments-content-incremental-backup-high"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  metric_name         = "scripted-metrics"
+  namespace           = "${var.environment}/MarkLogic"
+  period              = 300
+  statistic           = "Maximum"
+  threshold           = 900 //15 hours in minutes
+
+  alarm_description  = "Longer than expected since payments-content was incrementally backed up"
+  alarm_actions      = [var.alarms_sns_topic_arn]
+  ok_actions         = [var.alarms_sns_topic_arn]
+  treat_missing_data = "missing"
+  dimensions = {
+    "metric" = "payments-content-minutes-since-incr-backup"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "time_since_delta_content_incremental_backup_high" {
+  alarm_name          = "marklogic-${var.environment}-time-since-delta-content-incremental-backup-high"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  metric_name         = "scripted-metrics"
+  namespace           = "${var.environment}/MarkLogic"
+  period              = 300
+  statistic           = "Maximum"
+  threshold           = 900 //15 hours in minutes
+
+  alarm_description  = "Longer than expected since delta-content was incrementally backed up"
+  alarm_actions      = [var.alarms_sns_topic_arn]
+  ok_actions         = [var.alarms_sns_topic_arn]
+  treat_missing_data = "missing"
+  dimensions = {
+    "metric" = "delta-content-minutes-since-incr-backup"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "task_server_queue_size_high" {
+  alarm_name          = "marklogic-${var.environment}-task-server-queue-size-high"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 18
+  metric_name         = "scripted-metrics"
+  namespace           = "${var.environment}/MarkLogic"
+  period              = 300
+  statistic           = "Minimum"
+  threshold           = 1000
+
+  alarm_description  = "Task server queue size is larger than expected"
+  alarm_actions      = [var.alarms_sns_topic_arn]
+  ok_actions         = [var.alarms_sns_topic_arn]
+  treat_missing_data = "missing"
+  dimensions = {
+    "metric" = "task-server-total-queue-size"
+  }
+}


### PR DESCRIPTION
Thresholds chosen by looking at last 2 weeks of metrics on production environment

Testing: Manually checked that the alarms exist for test, have not checked that the alarms trigger correctly but no reason to think they wouldn't 🤞 
Risks: Not functioning alarms could mean we don't get alerted to issues
Documentation: This PR, [the ticket](https://dluhcdigital.atlassian.net/browse/DT-547), will update [Ticket Specific Release Actions](https://dluhcdigital.atlassian.net/wiki/spaces/DT/pages/3375147/Ticket+specific+release+actions) to include deploying terraform to prod (and staging) and also to check that the thresholds look correct against the existing data