### PR TITLE
DT-525 Update geo location restriction for auth service

### DIFF
--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -310,8 +310,8 @@ module "cloudfront_distributions" {
       acm_certificate_arn = module.communities_only_ssl_certs.cloudfront_certs["keycloak"].arn
     }
     keycloak_path_ip_allowlist = local.cloudfront_ip_allowlists.delta_api
-    # Home Connections claim their servers are in the UK but their supplier is international so can be geolocated incorrectly
-    geo_restriction_countries = null
+    # Home Connections claim their servers are in the UK, but they currently get geo-located to US
+    geo_restriction_countries = ["GB", "IE", "US"]
   }
   cpm = {
     alb = module.public_albs.cpm


### PR DESCRIPTION
Home connections have said they can still communicate with the staging API, so should be good to restrict prod too