### PR TITLE
Update packets dropped alarm to go to security sns topic

### DIFF
--- a/terraform/modules/networking/firewall_monitoring.tf
+++ b/terraform/modules/networking/firewall_monitoring.tf
@@ -132,8 +132,8 @@ resource "aws_cloudwatch_metric_alarm" "dropped_packets" {
     Engine           = "Stateful"
   }
 
-  alarm_actions = [var.alarms_sns_topic_arn]
-  ok_actions    = [var.alarms_sns_topic_arn]
+  alarm_actions = [var.security_alarms_sns_topic_arn]
+  ok_actions    = [var.security_alarms_sns_topic_arn]
 }
 
 resource "aws_cloudwatch_metric_alarm" "nat_bytes_out" {

--- a/terraform/modules/networking/firewall_monitoring.tf
+++ b/terraform/modules/networking/firewall_monitoring.tf
@@ -156,6 +156,6 @@ resource "aws_cloudwatch_metric_alarm" "nat_bytes_out" {
     NatGatewayId = aws_nat_gateway.nat_gateway.id
   }
 
-  alarm_actions = [var.alarms_sns_topic_arn]
-  ok_actions    = [var.alarms_sns_topic_arn]
+  alarm_actions = [var.security_alarms_sns_topic_arn]
+  ok_actions    = [var.security_alarms_sns_topic_arn]
 }

--- a/terraform/modules/networking/variables.tf
+++ b/terraform/modules/networking/variables.tf
@@ -75,6 +75,11 @@ variable "alarms_sns_topic_arn" {
   type        = string
 }
 
+variable "security_alarms_sns_topic_arn" {
+  description = "SNS topic ARN to send security alarm notifications to"
+  type        = string
+}
+
 variable "attack_iq_testing_domains" {
   description = "List of domains to allow through the Network Firewall for AttackIQ security testing purposes. See DT-527"
   type        = list(string)

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -112,6 +112,7 @@ module "networking" {
   firewall_cloudwatch_log_expiration_days = local.cloudwatch_log_expiration_days
   vpc_flow_cloudwatch_log_expiration_days = local.cloudwatch_log_expiration_days
   alarms_sns_topic_arn                    = module.notifications.alarms_sns_topic_arn
+  security_alarms_sns_topic_arn           = module.notifications.security_sns_topic_arn
 }
 
 module "bastion_log_group" {

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -74,6 +74,7 @@ module "networking" {
     "send-email-attackiq-ntm.com",
     "validation-attackiq-ntm.com"
   ]
+  security_alarms_sns_topic_arn = module.notifications.security_sns_topic_arn
 }
 
 resource "tls_private_key" "bastion_ssh_key" {

--- a/terraform/test/main.tf
+++ b/terraform/test/main.tf
@@ -89,6 +89,7 @@ module "networking" {
   firewall_cloudwatch_log_expiration_days = local.cloudwatch_log_expiration_days
   vpc_flow_cloudwatch_log_expiration_days = local.cloudwatch_log_expiration_days
   alarms_sns_topic_arn                    = module.notifications.alarms_sns_topic_arn
+  security_alarms_sns_topic_arn           = module.notifications.security_sns_topic_arn
 }
 
 resource "tls_private_key" "bastion_ssh_key" {


### PR DESCRIPTION
Update packets dropped alarm to go to security sns topic rather than metric one
(successfully applied to test but not tested in any way)