### PR TITLE
IP restrict production API

### DIFF
--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -300,8 +300,8 @@ module "cloudfront_distributions" {
       acm_certificate_arn = module.communities_only_ssl_certs.cloudfront_certs["api"].arn
     }
     ip_allowlist = local.cloudfront_ip_allowlists.delta_api
-    # Home Connections claim their servers are in the UK but their supplier is international so can be geolocated incorrectly
-    geo_restriction_countries = null
+    # Home Connections claim their servers are in the UK, but they currently get geo-located to US
+    geo_restriction_countries = ["GB", "IE", "US"]
   }
   keycloak = {
     alb = module.public_albs.auth


### PR DESCRIPTION
Doesn't really matter because there's an IP allowlist, but should mean bots from other countries stop setting off the WAF alarm.

Staging is already IP restricted in this way, as is production Keycloak/auth service.