### PR TITLE
DT-742 Create Object Locked backup bucket

### DIFF
--- a/terraform/modules/backup_replication_bucket/main.tf
+++ b/terraform/modules/backup_replication_bucket/main.tf
@@ -14,8 +14,11 @@ variable "object_expiration_days" {
   type = number
 }
 
-output "bucket_arn" {
-  value = module.bucket.bucket_arn
+output "bucket" {
+  value = {
+    arn  = module.bucket.bucket_arn
+    name = module.bucket.bucket
+  }
 }
 
 # S3 bucket with Object Lock enabled for replicating backups into

--- a/terraform/modules/backup_replication_bucket/main.tf
+++ b/terraform/modules/backup_replication_bucket/main.tf
@@ -1,0 +1,83 @@
+variable "environment" {
+  type = string
+}
+
+variable "s3_access_log_expiration_days" {
+  type = number
+}
+
+variable "compliance_retention_days" {
+  type = number
+}
+
+variable "object_expiration_days" {
+  type = number
+}
+
+output "bucket_arn" {
+  value = module.bucket.bucket_arn
+}
+
+# S3 bucket with Object Lock enabled for replicating backups into
+module "bucket" {
+  source = "../s3_bucket"
+
+  bucket_name                        = "dluhc-backup-locked-${var.environment}"
+  access_log_bucket_name             = "dluhc-backup-locked-access-logs-${var.environment}"
+  noncurrent_version_expiration_days = null # Specify our own lifecycle policy
+  access_s3_log_expiration_days      = var.s3_access_log_expiration_days
+
+  object_lock_enabled = true
+}
+
+resource "aws_s3_bucket_object_lock_configuration" "object_locked_backup_bucket" {
+  bucket = module.bucket.bucket
+
+  rule {
+    default_retention {
+      mode = "COMPLIANCE"
+      days = var.compliance_retention_days
+    }
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "object_locked_backup_bucket" {
+  bucket = module.bucket.bucket
+
+  rule {
+    id = "noncurrent-version-expiration"
+
+    filter {}
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 7
+    }
+
+    # There shouldn't be many noncurrent objects since the expiration rule will delete them directly,
+    # so no harm in having this as a longer duration
+    noncurrent_version_expiration {
+      noncurrent_days = 180
+    }
+
+    status = "Enabled"
+  }
+
+  rule {
+    id = "expire"
+
+    filter {}
+
+    expiration {
+      days = var.object_expiration_days
+    }
+
+    status = "Enabled"
+  }
+
+  lifecycle {
+    precondition {
+      condition     = var.object_expiration_days > var.compliance_retention_days
+      error_message = "The value for object_expiration_days must be larger than compliance_retention_days."
+    }
+  }
+}

--- a/terraform/modules/marklogic/backup_buckets.tf
+++ b/terraform/modules/marklogic/backup_buckets.tf
@@ -23,6 +23,7 @@ module "daily_backup_bucket" {
 
 # We manage the weekly one with lifecycle rules
 # Transitioning objects to Glacier IR then eventually expiring them
+# This bucket is replicated to another bucket with Object Lock enabled
 module "weekly_backup_bucket" {
   source = "../s3_bucket"
 
@@ -66,6 +67,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "weekly_backup_bucket" {
         prefix = "${rule.value}/20"
       }
 
+      # TODO DT-742 Remove transition and reduce expiration once we're confident in replication
       transition {
         days          = 7
         storage_class = "GLACIER_IR"

--- a/terraform/modules/marklogic/backup_replication.tf
+++ b/terraform/modules/marklogic/backup_replication.tf
@@ -1,0 +1,105 @@
+# Replicate the weekly backups to another bucket that has Object Lock enabled to prevent accidental or malicious deletion.
+# MarkLogic 10 cannot backup directly to an S3 bucket with Object Lock enabled as it does not send the Content-MD5 header.
+
+data "aws_iam_policy_document" "assume_role" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["s3.amazonaws.com"]
+    }
+
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+resource "aws_iam_role" "backup_replication" {
+  name               = "s3-backup-replication-${var.environment}"
+  assume_role_policy = data.aws_iam_policy_document.assume_role.json
+}
+
+# tfsec:ignore:aws-iam-no-policy-wildcards
+data "aws_iam_policy_document" "backup_replication" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "s3:GetReplicationConfiguration",
+      "s3:ListBucket",
+    ]
+
+    resources = [module.weekly_backup_bucket.bucket_arn]
+  }
+
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "s3:GetObjectVersionForReplication",
+      "s3:GetObjectVersionAcl",
+      "s3:GetObjectVersionTagging",
+      "s3:GetObjectRetention",
+      "s3:GetObjectLegalHold",
+    ]
+
+    resources = ["${module.weekly_backup_bucket.bucket_arn}/*"]
+  }
+
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "s3:ReplicateObject",
+      "s3:ReplicateDelete",
+      "s3:ReplicateTags",
+    ]
+
+    resources = ["${var.backup_replication_bucket_arn}/*"]
+  }
+}
+
+resource "aws_iam_policy" "backup_replication" {
+  name   = "s3-backup-replication-${var.environment}"
+  policy = data.aws_iam_policy_document.backup_replication.json
+}
+
+resource "aws_iam_role_policy_attachment" "backup_replication" {
+  role       = aws_iam_role.backup_replication.name
+  policy_arn = aws_iam_policy.backup_replication.arn
+}
+
+resource "aws_s3_bucket_replication_configuration" "backup_replication" {
+  role   = aws_iam_role.backup_replication.arn
+  bucket = module.weekly_backup_bucket.bucket
+
+  rule {
+    id = "replicate-to-locked-bucket"
+
+    filter {}
+
+    status = "Enabled"
+
+    destination {
+      bucket        = var.backup_replication_bucket_arn
+      storage_class = "GLACIER_IR"
+
+      metrics {
+        status = "Enabled"
+      }
+    }
+
+    delete_marker_replication {
+      status = "Enabled"
+    }
+  }
+}
+
+resource "aws_s3_bucket_notification" "replication_notifications" {
+  bucket = module.weekly_backup_bucket.bucket
+
+  topic {
+    topic_arn = var.alarms_sns_topic_arn
+    events    = ["s3:Replication:OperationFailedReplication"]
+  }
+}

--- a/terraform/modules/marklogic/backup_replication.tf
+++ b/terraform/modules/marklogic/backup_replication.tf
@@ -55,7 +55,7 @@ data "aws_iam_policy_document" "backup_replication" {
       "s3:ReplicateTags",
     ]
 
-    resources = ["${var.backup_replication_bucket_arn}/*"]
+    resources = ["${var.backup_replication_bucket.arn}/*"]
   }
 }
 
@@ -69,19 +69,23 @@ resource "aws_iam_role_policy_attachment" "backup_replication" {
   policy_arn = aws_iam_policy.backup_replication.arn
 }
 
+locals {
+  replication_rule_id = "replicate-to-locked-bucket"
+}
+
 resource "aws_s3_bucket_replication_configuration" "backup_replication" {
   role   = aws_iam_role.backup_replication.arn
   bucket = module.weekly_backup_bucket.bucket
 
   rule {
-    id = "replicate-to-locked-bucket"
+    id = local.replication_rule_id
 
     filter {}
 
     status = "Enabled"
 
     destination {
-      bucket        = var.backup_replication_bucket_arn
+      bucket        = var.backup_replication_bucket.arn
       storage_class = "GLACIER_IR"
 
       metrics {

--- a/terraform/modules/marklogic/marklogic_iam.tf
+++ b/terraform/modules/marklogic/marklogic_iam.tf
@@ -164,8 +164,8 @@ data "aws_iam_policy_document" "ml_s3_backups" {
     ]
     effect = "Allow"
     resources = [
-      var.backup_replication_bucket_arn,
-      "${var.backup_replication_bucket_arn}/*",
+      var.backup_replication_bucket.arn,
+      "${var.backup_replication_bucket.arn}/*",
     ]
   }
   statement {

--- a/terraform/modules/marklogic/marklogic_iam.tf
+++ b/terraform/modules/marklogic/marklogic_iam.tf
@@ -159,6 +159,16 @@ data "aws_iam_policy_document" "ml_s3_backups" {
     ]
   }
   statement {
+    actions = [
+      "s3:GetEncryptionConfiguration", "s3:GetObject", "s3:GetBucketLocation", "s3:ListBucket"
+    ]
+    effect = "Allow"
+    resources = [
+      var.backup_replication_bucket_arn,
+      "${var.backup_replication_bucket_arn}/*",
+    ]
+  }
+  statement {
     actions   = ["kms:GenerateDataKey", "kms:DescribeKey", "kms:Decrypt"]
     effect    = "Allow"
     resources = [aws_kms_key.ml_backup_bucket_key.arn]

--- a/terraform/modules/marklogic/monitoring_dashboard.tf
+++ b/terraform/modules/marklogic/monitoring_dashboard.tf
@@ -396,6 +396,57 @@ resource "aws_cloudwatch_dashboard" "main" {
           }
         },
         {
+          "height" : 6,
+          "width" : 6,
+          "y" : 15,
+          "x" : 6,
+          "type" : "metric",
+          "properties" : {
+            "metrics" : [
+              ["AWS/S3", "BucketSizeBytes", "BucketName", module.daily_backup_bucket.bucket, "StorageType", "StandardStorage", { "color" : "#17becf" }],
+              [{ "expression" : "weekly_standard+weekly_glacier", "label" : "Weekly backups", "color" : "#9467bd" }],
+              ["AWS/S3", "BucketSizeBytes", "BucketName", module.weekly_backup_bucket.bucket, "StorageType", "StandardStorage", { "visible" : false, "id" : "weekly_standard" }],
+              ["AWS/S3", "BucketSizeBytes", "BucketName", module.weekly_backup_bucket.bucket, "StorageType", "GlacierInstantRetrievalStorage", { "visible" : false, "id" : "weekly_glacier" }],
+              ["AWS/S3", "BucketSizeBytes", "BucketName", var.backup_replication_bucket.name, "StorageType", "GlacierInstantRetrievalStorage", { "color" : "#c5b0d5" }]
+            ],
+            "view" : "timeSeries",
+            "stacked" : false,
+            "region" : data.aws_region.current.name,
+            "stat" : "Average",
+            "period" : 86400,
+            "title" : "Backup size"
+            "yAxis" : {
+              "left" : {
+                "min" : 0
+              }
+            }
+          }
+        },
+        {
+          "height" : 6,
+          "width" : 6,
+          "y" : 21,
+          "x" : 6,
+          "type" : "metric",
+          "properties" : {
+            "metrics" : [
+              ["AWS/S3", "OperationsPendingReplication", "SourceBucket", module.weekly_backup_bucket.bucket, "DestinationBucket", var.backup_replication_bucket.name, "RuleId", local.replication_rule_id, { "color" : "#17becf" }],
+              [".", "OperationsFailedReplication", ".", ".", ".", ".", ".", ".", { "color" : "#d62728" }]
+            ],
+            "view" : "timeSeries",
+            "stacked" : false,
+            "region" : data.aws_region.current.name,
+            "stat" : "Average",
+            "period" : 300,
+            "title" : "Backup replication"
+            "yAxis" : {
+              "left" : {
+                "min" : 0
+              }
+            }
+          }
+        },
+        {
           "height" : 5,
           "width" : 24,
           "y" : 27,

--- a/terraform/modules/marklogic/variables.tf
+++ b/terraform/modules/marklogic/variables.tf
@@ -105,6 +105,9 @@ variable "marklogic_ami_version" {
   }
 }
 
-variable "backup_replication_bucket_arn" {
-  type = string
+variable "backup_replication_bucket" {
+  type = object({
+    arn  = string
+    name = string
+  })
 }

--- a/terraform/modules/marklogic/variables.tf
+++ b/terraform/modules/marklogic/variables.tf
@@ -104,3 +104,7 @@ variable "marklogic_ami_version" {
     error_message = "Only specific versions allowed, configure AMIs for others"
   }
 }
+
+variable "backup_replication_bucket_arn" {
+  type = string
+}

--- a/terraform/modules/marklogic_restore_rehearsal/marklogic_iam.tf
+++ b/terraform/modules/marklogic_restore_rehearsal/marklogic_iam.tf
@@ -108,7 +108,9 @@ data "aws_iam_policy_document" "ml_s3_backups" {
       var.daily_backup_bucket_arn,
       "${var.daily_backup_bucket_arn}/*",
       var.weekly_backup_bucket_arn,
-      "${var.weekly_backup_bucket_arn}/*"
+      "${var.weekly_backup_bucket_arn}/*",
+      var.locked_backup_replication_bucket_arn,
+      "${var.locked_backup_replication_bucket_arn}/*"
     ]
   }
   statement {

--- a/terraform/modules/marklogic_restore_rehearsal/variables.tf
+++ b/terraform/modules/marklogic_restore_rehearsal/variables.tf
@@ -53,6 +53,11 @@ variable "weekly_backup_bucket_arn" {
   description = "From the main ML module"
 }
 
+variable "locked_backup_replication_bucket_arn" {
+  type        = string
+  description = "ARN of bucket storing replicated Object Locked backups"
+}
+
 variable "backup_key" {
   type        = string
   description = "From the main ML module, aws_kms_key.ml_backup_bucket_key.arn"

--- a/terraform/modules/notifications/main.tf
+++ b/terraform/modules/notifications/main.tf
@@ -12,6 +12,30 @@ resource "aws_sns_topic" "alarm_sns_topic" {
   display_name = "Notifications for change in metric alarm status"
 }
 
+resource "aws_sns_topic_policy" "alarm_sns_topic_allow_s3_events" {
+  arn    = aws_sns_topic.alarm_sns_topic.arn
+  policy = data.aws_iam_policy_document.alarm_sns_topic_allow_s3_events.json
+}
+
+data "aws_iam_policy_document" "alarm_sns_topic_allow_s3_events" {
+  statement {
+    effect  = "Allow"
+    actions = ["SNS:Publish"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["s3.amazonaws.com"]
+    }
+
+    resources = [aws_sns_topic.alarm_sns_topic.arn]
+    condition {
+      test     = "StringEquals"
+      variable = "AWS:SourceAccount"
+      values   = [data.aws_caller_identity.current.account_id]
+    }
+  }
+}
+
 resource "aws_sns_sms_preferences" "update_sms_prefs" {
   default_sender_id = "Delta"
 }

--- a/terraform/modules/notifications/main.tf
+++ b/terraform/modules/notifications/main.tf
@@ -3,6 +3,8 @@ provider "aws" {
   region = "us-east-1"
 }
 
+data "aws_caller_identity" "current" {}
+
 # Non sensitive
 # tfsec:ignore:aws-sns-enable-topic-encryption
 resource "aws_sns_topic" "alarm_sns_topic" {
@@ -96,5 +98,10 @@ data "aws_iam_policy_document" "allow_guard_duty_events" {
     }
 
     resources = [aws_sns_topic.security_sns_topic.arn]
+    condition {
+      test     = "StringEquals"
+      variable = "AWS:SourceAccount"
+      values   = [data.aws_caller_identity.current.account_id]
+    }
   }
 }

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -177,6 +177,15 @@ module "marklogic_patch_maintenance_window" {
   enabled = true
 }
 
+module "backup_replication_bucket" {
+  source = "../modules/backup_replication_bucket"
+
+  environment                   = local.environment
+  s3_access_log_expiration_days = local.s3_log_expiration_days
+  compliance_retention_days     = 14 # TODO DT-742 Increase once happy with replication
+  object_expiration_days        = 90
+}
+
 module "marklogic" {
   source = "../modules/marklogic"
 
@@ -208,6 +217,7 @@ module "marklogic" {
     local.all_notifications_email_addresses,
     ["deltastatsupport@levellingup.gov.uk"]
   )
+  backup_replication_bucket_arn = module.backup_replication_bucket.bucket_arn
 }
 
 module "gh_runner" {

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -217,7 +217,7 @@ module "marklogic" {
     local.all_notifications_email_addresses,
     ["deltastatsupport@levellingup.gov.uk"]
   )
-  backup_replication_bucket_arn = module.backup_replication_bucket.bucket_arn
+  backup_replication_bucket = module.backup_replication_bucket.bucket
 }
 
 module "gh_runner" {

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -263,6 +263,15 @@ module "marklogic_patch_maintenance_window" {
   enabled = true
 }
 
+module "backup_replication_bucket" {
+  source = "../modules/backup_replication_bucket"
+
+  environment                   = local.environment
+  s3_access_log_expiration_days = local.s3_log_expiration_days
+  compliance_retention_days     = 1
+  object_expiration_days        = 90
+}
+
 module "marklogic" {
   source = "../modules/marklogic"
 
@@ -291,6 +300,7 @@ module "marklogic" {
   data_disk_usage_alarm_threshold_percent = 70
   dap_external_role_arns                  = var.dap_external_role_arns
   dap_job_notification_emails             = local.all_notifications_email_addresses
+  backup_replication_bucket_arn           = module.backup_replication_bucket.bucket_arn
 }
 
 module "gh_runner" {

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -300,7 +300,7 @@ module "marklogic" {
   data_disk_usage_alarm_threshold_percent = 70
   dap_external_role_arns                  = var.dap_external_role_arns
   dap_job_notification_emails             = local.all_notifications_email_addresses
-  backup_replication_bucket_arn           = module.backup_replication_bucket.bucket_arn
+  backup_replication_bucket               = module.backup_replication_bucket.bucket
 }
 
 module "gh_runner" {

--- a/terraform/test/main.tf
+++ b/terraform/test/main.tf
@@ -317,7 +317,7 @@ module "marklogic" {
   data_disk_usage_alarm_threshold_percent = 70
   dap_external_role_arns                  = var.dap_external_role_arns
   dap_job_notification_emails             = local.all_notifications_email_addresses
-  backup_replication_bucket_arn           = module.backup_replication_bucket.bucket_arn
+  backup_replication_bucket               = module.backup_replication_bucket.bucket
 }
 
 moved {

--- a/terraform/test/main.tf
+++ b/terraform/test/main.tf
@@ -279,7 +279,6 @@ module "marklogic_patch_maintenance_window" {
   subscribed_emails = local.all_notifications_email_addresses
 }
 
-# TODO DT-742 Do we want this in another region, maybe London?
 module "backup_replication_bucket" {
   source = "../modules/backup_replication_bucket"
 

--- a/terraform/test/main.tf
+++ b/terraform/test/main.tf
@@ -279,6 +279,15 @@ module "marklogic_patch_maintenance_window" {
   subscribed_emails = local.all_notifications_email_addresses
 }
 
+module "backup_replication_bucket" {
+  source = "../modules/backup_replication_bucket"
+
+  environment                   = local.environment
+  s3_access_log_expiration_days = local.s3_log_expiration_days
+  compliance_retention_days     = 1
+  object_expiration_days        = 30
+}
+
 module "marklogic" {
   source = "../modules/marklogic"
 
@@ -307,6 +316,12 @@ module "marklogic" {
   data_disk_usage_alarm_threshold_percent = 70
   dap_external_role_arns                  = var.dap_external_role_arns
   dap_job_notification_emails             = local.all_notifications_email_addresses
+  backup_replication_bucket_arn           = module.backup_replication_bucket.bucket_arn
+}
+
+moved {
+  from = module.marklogic.module.object_locked_backup_replication_bucket
+  to   = module.backup_replication_bucket.module.bucket
 }
 
 module "gh_runner" {

--- a/terraform/test/main.tf
+++ b/terraform/test/main.tf
@@ -279,6 +279,7 @@ module "marklogic_patch_maintenance_window" {
   subscribed_emails = local.all_notifications_email_addresses
 }
 
+# TODO DT-742 Do we want this in another region, maybe London?
 module "backup_replication_bucket" {
   source = "../modules/backup_replication_bucket"
 

--- a/terraform/test/main.tf
+++ b/terraform/test/main.tf
@@ -320,11 +320,6 @@ module "marklogic" {
   backup_replication_bucket               = module.backup_replication_bucket.bucket
 }
 
-moved {
-  from = module.marklogic.module.object_locked_backup_replication_bucket
-  to   = module.backup_replication_bucket.module.bucket
-}
-
 module "gh_runner" {
   source = "../modules/github_runner"
 


### PR DESCRIPTION
New bucket to replicate weekly backups to with Object Lock enabled.

* MarkLogic 10 can't write backups directly to a bucket with Object Lock enabled, so instead I've made another bucket that can be replicated to
  * This is an annoying extra step, but should mean less work if we ever separate the replicated backup into another AWS account, which we'd like to do at some point anyway
* I've put the replication bucket in the same region as the main one, should we move it to London? S3 Ireland becoming unavailable seems pretty unlikely, but it should be easy to do
* I've tested backing up to the weekly bucket and then restoring from the replica bucket (payments-content on test)
* Added a notification for replication failure, though haven't tested it
* Only new files are replicated, existing ones are not
* What should the retention and expiration period be?
  * 14 days for compliance retention? That's not very long, but if something messes up we can't delete it
  * There doesn't seem much point keeping two copies of all the backups, so maybe reduce expiration on the main bucket to 14 days?