### PR TITLE
DT-742 Further S3 cost saving changes

### DIFF
--- a/terraform/modules/marklogic/backup_buckets.tf
+++ b/terraform/modules/marklogic/backup_buckets.tf
@@ -18,7 +18,9 @@ module "daily_backup_bucket" {
   bucket_name                        = "dluhc-daily-ml-backup-${var.environment}"
   access_log_bucket_name             = "dluhc-daily-backup-access-logs-${var.environment}"
   noncurrent_version_expiration_days = 3
-  access_s3_log_expiration_days      = var.backup_s3_log_expiration_days
+  # We configure MarkLogic to keep at most 3 weeks of daily backups, which are then deleted 3 days later,
+  # so no reason to keep access logs for much longer than that
+  access_s3_log_expiration_days = min(var.backup_s3_log_expiration_days, 90)
 }
 
 # We manage the weekly one with lifecycle rules

--- a/terraform/modules/marklogic/backup_buckets.tf
+++ b/terraform/modules/marklogic/backup_buckets.tf
@@ -17,7 +17,7 @@ module "daily_backup_bucket" {
 
   bucket_name                        = "dluhc-daily-ml-backup-${var.environment}"
   access_log_bucket_name             = "dluhc-daily-backup-access-logs-${var.environment}"
-  noncurrent_version_expiration_days = 5
+  noncurrent_version_expiration_days = 3
   access_s3_log_expiration_days      = var.backup_s3_log_expiration_days
 }
 

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -396,7 +396,7 @@ module "cloudtrail" {
   environment                          = local.environment
   include_data_events_for_bucket_names = ["data-collection-service-tfstate-production"]
   cloudwatch_log_expiration_days       = local.cloudwatch_log_expiration_days
-  s3_log_expiration_days               = local.s3_log_expiration_days
+  s3_log_expiration_days               = 90 # We're mostly interested in the CloudWatch logs, the central DLUHC account keeps a CloudTrail in S3 for security investigations
 }
 
 module "iam_roles" {


### PR DESCRIPTION
Hard to estimate the actual cost saving because we don't get a cost breakdown per bucket, but combined with https://github.com/communitiesuk/delta-marklogic-deploy/pull/25 this should reduce the size of the daily backup bucket by ~20%, and stop the other two buckets growing further. Eyeballing it that's probably ~$100/month.