### PR TITLE
Fix ML metrics

### DIFF
--- a/terraform/modules/marklogic/monitoring_alarms.tf
+++ b/terraform/modules/marklogic/monitoring_alarms.tf
@@ -271,9 +271,11 @@ resource "aws_cloudwatch_metric_alarm" "time_since_payments_content_backup_high"
   statistic           = "Maximum"
   threshold           = 1800 //30 hours in minutes
 
-  alarm_description  = "Longer than expected since payments-content was backed up"
-  alarm_actions      = [var.alarms_sns_topic_arn]
-  ok_actions         = [var.alarms_sns_topic_arn]
+  alarm_description         = "Longer than expected since payments-content was backed up"
+  alarm_actions             = [var.alarms_sns_topic_arn]
+  ok_actions                = [var.alarms_sns_topic_arn]
+  insufficient_data_actions = [var.alarms_sns_topic_arn]
+
   treat_missing_data = "missing"
   dimensions = {
     "metric" = "payments-content-minutes-since-backup"
@@ -290,9 +292,11 @@ resource "aws_cloudwatch_metric_alarm" "time_since_delta_content_backup_high" {
   statistic           = "Maximum"
   threshold           = 1800 //30 hours in minutes
 
-  alarm_description  = "Longer than expected since delta-content was backed up"
-  alarm_actions      = [var.alarms_sns_topic_arn]
-  ok_actions         = [var.alarms_sns_topic_arn]
+  alarm_description         = "Longer than expected since delta-content was backed up"
+  alarm_actions             = [var.alarms_sns_topic_arn]
+  ok_actions                = [var.alarms_sns_topic_arn]
+  insufficient_data_actions = [var.alarms_sns_topic_arn]
+
   treat_missing_data = "missing"
   dimensions = {
     "metric" = "delta-content-minutes-since-backup"
@@ -309,9 +313,11 @@ resource "aws_cloudwatch_metric_alarm" "time_since_payments_content_incremental_
   statistic           = "Maximum"
   threshold           = 900 //15 hours in minutes
 
-  alarm_description  = "Longer than expected since payments-content was incrementally backed up"
-  alarm_actions      = [var.alarms_sns_topic_arn]
-  ok_actions         = [var.alarms_sns_topic_arn]
+  alarm_description         = "Longer than expected since payments-content was incrementally backed up"
+  alarm_actions             = [var.alarms_sns_topic_arn]
+  ok_actions                = [var.alarms_sns_topic_arn]
+  insufficient_data_actions = [var.alarms_sns_topic_arn]
+
   treat_missing_data = "missing"
   dimensions = {
     "metric" = "payments-content-minutes-since-incr-backup"
@@ -328,9 +334,11 @@ resource "aws_cloudwatch_metric_alarm" "time_since_delta_content_incremental_bac
   statistic           = "Maximum"
   threshold           = 900 // 15 hours in minutes
 
-  alarm_description  = "Longer than expected since delta-content was incrementally backed up"
-  alarm_actions      = [var.alarms_sns_topic_arn]
-  ok_actions         = [var.alarms_sns_topic_arn]
+  alarm_description         = "Longer than expected since delta-content was incrementally backed up"
+  alarm_actions             = [var.alarms_sns_topic_arn]
+  ok_actions                = [var.alarms_sns_topic_arn]
+  insufficient_data_actions = [var.alarms_sns_topic_arn]
+
   treat_missing_data = "missing"
   dimensions = {
     "metric" = "delta-content-minutes-since-incr-backup"
@@ -347,12 +355,14 @@ resource "aws_cloudwatch_metric_alarm" "task_server_queue_size_high" {
   statistic           = "Minimum"
   threshold           = 1000
 
-  alarm_description  = <<EOF
+  alarm_description         = <<EOF
 Task server queue size is larger than expected.
 Consider clearing the task queue.
   EOF
-  alarm_actions      = [var.alarms_sns_topic_arn]
-  ok_actions         = [var.alarms_sns_topic_arn]
+  alarm_actions             = [var.alarms_sns_topic_arn]
+  ok_actions                = [var.alarms_sns_topic_arn]
+  insufficient_data_actions = [var.alarms_sns_topic_arn]
+
   treat_missing_data = "missing"
   dimensions = {
     "metric" = "task-server-total-queue-size"

--- a/terraform/modules/marklogic/templates/metrics_config_ssm_doc.yml
+++ b/terraform/modules/marklogic/templates/metrics_config_ssm_doc.yml
@@ -12,6 +12,7 @@ mainSteps:
     inputs:
       timeoutSeconds: '120'
       runCommand:
+        - "cloud-init status --wait"
         - "mkdir -p /metrics-cron"
         - "aws s3 cp --region eu-west-1 {{ShellScriptLocation}} /metrics-cron/metrics-cron.sh"
         - "chmod +x /metrics-cron/metrics-cron.sh"


### PR DESCRIPTION
These have been broken in all three environments since the update. The setup script failed to create the log group as `jq` wasn't installed, presumably because the user data script hadn't finished installing it yet. I've added a wait command, though haven't tried recreating any ML instances. AWS RunCommand ignores return codes so it looks like it succeeded.

The alarms didn't have insufficient_data actions, so we didn't get notified of the problem.