### PR TITLE
Add silent flag to curl commands in ML patching scripts

### DIFF
--- a/terraform/modules/marklogic/check_forest_state.sh
+++ b/terraform/modules/marklogic/check_forest_state.sh
@@ -6,7 +6,7 @@ echo "Starting to check forest state at $(date --iso-8601=seconds)"
 set +e
 ML_USER=$1
 ML_PASS=$2
-response=$(curl --anyauth --user "$ML_USER":"$ML_PASS" -X POST -d @/patching/check_forest_state.xqy \
+response=$(curl -sS --anyauth --user "$ML_USER":"$ML_PASS" -X POST -d @/patching/check_forest_state.xqy \
                 -H "Content-type: application/x-www-form-urlencoded" \
                 -H "Accept: text/plain" \
                 http://localhost:8002/v1/eval || echo "output:Connection failed")
@@ -24,7 +24,7 @@ if [ "READY_FOR_RESTART" != "$FOREST_STATUS" ]; then
       fi
 
       sleep 10
-      response=$(curl --anyauth --user "$ML_USER":"$ML_PASS" -X POST -d @/patching/check_forest_state.xqy \
+      response=$(curl -sS --anyauth --user "$ML_USER":"$ML_PASS" -X POST -d @/patching/check_forest_state.xqy \
                       -H "Content-type: application/x-www-form-urlencoded" \
                       -H "Accept: text/plain" \
                       http://localhost:8002/v1/eval || echo "output:Connection failed")

--- a/terraform/modules/marklogic/final_forest_state.sh
+++ b/terraform/modules/marklogic/final_forest_state.sh
@@ -12,7 +12,7 @@ ML_PASS=$(echo $ML_USER_PASS | jq -r '.password')
 aws s3 cp --region ${AWS_REGION} s3://${MARKLOGIC_CONFIG_BUCKET}/final_forest_state.xqy /patching/final_forest_state.xqy
 
 set +e
-response=$(curl --anyauth --user "$ML_USER":"$ML_PASS" -X POST -d @/patching/final_forest_state.xqy \
+response=$(curl -sS --anyauth --user "$ML_USER":"$ML_PASS" -X POST -d @/patching/final_forest_state.xqy \
                -H "Content-type: application/x-www-form-urlencoded" \
                -H "Accept: text/plain" \
                http://localhost:8002/v1/eval || echo "output:Failed connecting to Marklogic")
@@ -29,7 +29,7 @@ if [ "ALL_FORESTS_IN_CORRECT_STATE" != "$STATUS" ]; then
     fi
 
     sleep 10
-    response=$(curl --anyauth --user "$ML_USER":"$ML_PASS" -X POST -d @/patching/final_forest_state.xqy \
+    response=$(curl -sS --anyauth --user "$ML_USER":"$ML_PASS" -X POST -d @/patching/final_forest_state.xqy \
                    -H "Content-type: application/x-www-form-urlencoded" \
                    -H "Accept: text/plain" \
                    http://localhost:8002/v1/eval || echo "output:Failed connecting to Marklogic")

--- a/terraform/modules/marklogic/restart_server.sh
+++ b/terraform/modules/marklogic/restart_server.sh
@@ -17,7 +17,7 @@ printf 'xquery=
 
 echo "Restarting Marklogic server"
 
-curl --anyauth --user "$ML_USER":"$ML_PASS" -X POST -d @/patching/restart_server.xqy \
+curl -sS --anyauth --user "$ML_USER":"$ML_PASS" -X POST -d @/patching/restart_server.xqy \
                -H "Content-type: application/x-www-form-urlencoded" \
                -H "Accept: text/plain" \
                http://localhost:8002/v1/eval


### PR DESCRIPTION
The maintenance window log was filled up with curl progress this morning when test ML was broken.