### PR TITLE
Prevent CodeArtifact delete and export infra support role name

### DIFF
--- a/terraform/modules/iam_roles/outputs.tf
+++ b/terraform/modules/iam_roles/outputs.tf
@@ -1,0 +1,3 @@
+output "infra_support_role_name" {
+  value = aws_iam_role.infrastructure_support.name
+}

--- a/terraform/modules/iam_roles/policies.tf
+++ b/terraform/modules/iam_roles/policies.tf
@@ -244,6 +244,13 @@ data "aws_iam_policy_document" "infra_support" {
   }
 
   statement {
+    sid       = "PreventCodeArtifactPackageDeletion"
+    effect    = "Deny"
+    actions   = ["codeartifact:Delete*"]
+    resources = ["*"]
+  }
+
+  statement {
     sid = "UseSessionManagerKey"
     actions = [
       "kms:GenerateDataKey"

--- a/terraform/production/outputs.tf
+++ b/terraform/production/outputs.tf
@@ -148,3 +148,7 @@ output "auth_listener_arn" {
 output "auth_internal_alb" {
   value = module.auth_internal_alb.alb
 }
+
+output "infra_support_iam_role_name" {
+  value = module.iam_roles.infra_support_role_name
+}

--- a/terraform/staging/outputs.tf
+++ b/terraform/staging/outputs.tf
@@ -161,3 +161,7 @@ output "auth_listener_arn" {
 output "auth_internal_alb" {
   value = module.auth_internal_alb.alb
 }
+
+output "infra_support_iam_role_name" {
+  value = module.iam_roles.infra_support_role_name
+}

--- a/terraform/test/outputs.tf
+++ b/terraform/test/outputs.tf
@@ -176,3 +176,7 @@ output "auth_listener_arn" {
 output "auth_internal_alb" {
   value = module.auth_internal_alb.alb
 }
+
+output "infra_support_iam_role_name" {
+  value = module.iam_roles.infra_support_role_name
+}


### PR DESCRIPTION
For https://github.com/communitiesuk/delta/pull/1448.
Only production actually needs the output for now, but I figured may as well keep them consistent.