### PR TITLE
DT-371 Move EBS backup role and SNS topic to separate module

### DIFF
--- a/terraform/modules/ebs_backup/outputs.tf
+++ b/terraform/modules/ebs_backup/outputs.tf
@@ -1,0 +1,7 @@
+output "role_arn" {
+  value = aws_iam_role.ebs_backup.arn
+}
+
+output "sns_topic_arn" {
+  value = aws_sns_topic.ebs_backup_completed.arn
+}

--- a/terraform/modules/ebs_backup/role.tf
+++ b/terraform/modules/ebs_backup/role.tf
@@ -1,0 +1,34 @@
+data "aws_iam_policy_document" "backup_assume_role" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    effect  = "Allow"
+    principals {
+      type        = "Service"
+      identifiers = ["backup.amazonaws.com"]
+    }
+  }
+  version = "2012-10-17"
+}
+
+resource "aws_iam_role" "ebs_backup" {
+  name               = "aws-backup-service-role-${var.environment}"
+  assume_role_policy = data.aws_iam_policy_document.backup_assume_role.json
+}
+
+data "aws_iam_policy" "service_backup" {
+  name = "AWSBackupServiceRolePolicyForBackup"
+}
+
+data "aws_iam_policy" "service_restore" {
+  name = "AWSBackupServiceRolePolicyForRestores"
+}
+
+resource "aws_iam_role_policy_attachment" "service_backup" {
+  policy_arn = data.aws_iam_policy.service_backup.arn
+  role       = aws_iam_role.ebs_backup.name
+}
+
+resource "aws_iam_role_policy_attachment" "service_restore" {
+  policy_arn = data.aws_iam_policy.service_restore.arn
+  role       = aws_iam_role.ebs_backup.name
+}

--- a/terraform/modules/ebs_backup/sns.tf
+++ b/terraform/modules/ebs_backup/sns.tf
@@ -1,0 +1,35 @@
+
+# SNS topic for errors with EBS backups. Non-sensitive.
+# tfsec:ignore:aws-sns-enable-topic-encryption
+resource "aws_sns_topic" "ebs_backup_completed" {
+  name = "ebs-backup-errors-${var.environment}"
+}
+
+data "aws_iam_policy_document" "ebs_backup_sns" {
+  statement {
+    actions = ["sns:Publish"]
+    effect  = "Allow"
+    principals {
+      type        = "Service"
+      identifiers = ["backup.amazonaws.com"]
+    }
+    resources = [aws_sns_topic.ebs_backup_completed.arn]
+  }
+}
+
+resource "aws_sns_topic_policy" "ebs_backup" {
+  arn    = aws_sns_topic.ebs_backup_completed.arn
+  policy = data.aws_iam_policy_document.ebs_backup_sns.json
+}
+
+resource "aws_sns_topic_subscription" "ebs_backup_errors" {
+  for_each = toset(var.ebs_backup_error_notification_emails)
+
+  topic_arn = aws_sns_topic.ebs_backup_completed.arn
+  protocol  = "email"
+  endpoint  = each.value
+
+  filter_policy = jsonencode({
+    State = [{ "anything-but" : "COMPLETED" }]
+  })
+}

--- a/terraform/modules/ebs_backup/variables.tf
+++ b/terraform/modules/ebs_backup/variables.tf
@@ -1,0 +1,7 @@
+variable "environment" {
+  type = string
+}
+
+variable "ebs_backup_error_notification_emails" {
+  type = list(string)
+}

--- a/terraform/modules/marklogic/ebs_backup.tf
+++ b/terraform/modules/marklogic/ebs_backup.tf
@@ -1,38 +1,3 @@
-data "aws_iam_policy_document" "backup_assume_role" {
-  statement {
-    actions = ["sts:AssumeRole"]
-    effect  = "Allow"
-    principals {
-      type        = "Service"
-      identifiers = ["backup.amazonaws.com"]
-    }
-  }
-  version = "2012-10-17"
-}
-
-resource "aws_iam_role" "ebs_backup" {
-  name               = "aws-backup-service-role-${var.environment}"
-  assume_role_policy = data.aws_iam_policy_document.backup_assume_role.json
-}
-
-data "aws_iam_policy" "service_backup" {
-  name = "AWSBackupServiceRolePolicyForBackup"
-}
-
-data "aws_iam_policy" "service_restore" {
-  name = "AWSBackupServiceRolePolicyForRestores"
-}
-
-resource "aws_iam_role_policy_attachment" "service_backup" {
-  policy_arn = data.aws_iam_policy.service_backup.arn
-  role       = aws_iam_role.ebs_backup.name
-}
-
-resource "aws_iam_role_policy_attachment" "service_restore" {
-  policy_arn = data.aws_iam_policy.service_restore.arn
-  role       = aws_iam_role.ebs_backup.name
-}
-
 locals {
   ebs_backups = {
     schedule       = "cron(0 22 * * ? *)"
@@ -61,50 +26,15 @@ resource "aws_backup_plan" "ebs" {
 }
 
 resource "aws_backup_selection" "ebs" {
-  iam_role_arn = aws_iam_role.ebs_backup.arn
+  iam_role_arn = var.ebs_backup_role_arn
   name         = "marklogic-ebs-volumes-${var.environment}"
   plan_id      = aws_backup_plan.ebs.id
 
   resources = [for volume in aws_ebs_volume.marklogic_data_volumes : volume.arn]
 }
 
-# SNS topic for errors with the backup. Non-sensitive.
-# tfsec:ignore:aws-sns-enable-topic-encryption
-resource "aws_sns_topic" "ebs_backup_completed" {
-  name = "marklogic-ebs-backup-errors-${var.environment}"
-}
-
-data "aws_iam_policy_document" "ebs_backup_sns" {
-  statement {
-    actions = ["sns:Publish"]
-    effect  = "Allow"
-    principals {
-      type        = "Service"
-      identifiers = ["backup.amazonaws.com"]
-    }
-    resources = [aws_sns_topic.ebs_backup_completed.arn]
-  }
-}
-
-resource "aws_sns_topic_policy" "ebs_backup" {
-  arn    = aws_sns_topic.ebs_backup_completed.arn
-  policy = data.aws_iam_policy_document.ebs_backup_sns.json
-}
-
 resource "aws_backup_vault_notifications" "ebs_backup_completed" {
   backup_vault_name   = aws_backup_vault.ebs.name
-  sns_topic_arn       = aws_sns_topic.ebs_backup_completed.arn
+  sns_topic_arn       = var.ebs_backup_completed_sns_topic_arn
   backup_vault_events = ["BACKUP_JOB_COMPLETED"]
-}
-
-resource "aws_sns_topic_subscription" "ebs_backup_errors" {
-  for_each = toset(var.ebs_backup_error_notification_emails)
-
-  topic_arn = aws_sns_topic.ebs_backup_completed.arn
-  protocol  = "email"
-  endpoint  = each.value
-
-  filter_policy = jsonencode({
-    State = [{ "anything-but" : "COMPLETED" }]
-  })
 }

--- a/terraform/modules/marklogic/variables.tf
+++ b/terraform/modules/marklogic/variables.tf
@@ -41,8 +41,12 @@ variable "data_volume" {
   })
 }
 
-variable "ebs_backup_error_notification_emails" {
-  type = list(string)
+variable "ebs_backup_role_arn" {
+  type = string
+}
+
+variable "ebs_backup_completed_sns_topic_arn" {
+  type = string
 }
 
 variable "dap_job_notification_emails" {

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -186,6 +186,28 @@ module "backup_replication_bucket" {
   object_expiration_days        = 90
 }
 
+module "ebs_backup" {
+  source = "../modules/ebs_backup"
+
+  environment                          = local.environment
+  ebs_backup_error_notification_emails = local.all_notifications_email_addresses
+}
+
+moved {
+  from = module.marklogic.aws_iam_role.ebs_backup
+  to   = module.ebs_backup.aws_iam_role.ebs_backup
+}
+
+moved {
+  from = module.marklogic.aws_iam_role_policy_attachment.service_backup
+  to   = module.ebs_backup.aws_iam_role_policy_attachment.service_backup
+}
+
+moved {
+  from = module.marklogic.aws_iam_role_policy_attachment.service_restore
+  to   = module.ebs_backup.aws_iam_role_policy_attachment.service_restore
+}
+
 module "marklogic" {
   source = "../modules/marklogic"
 
@@ -203,7 +225,6 @@ module "marklogic" {
     throughput_MiB_per_sec = 1000
   }
 
-  ebs_backup_error_notification_emails    = local.all_notifications_email_addresses
   extra_instance_policy_arn               = module.session_manager_config.policy_arn
   app_cloudwatch_log_expiration_days      = local.cloudwatch_log_expiration_days
   patch_cloudwatch_log_expiration_days    = local.patch_cloudwatch_log_expiration_days
@@ -217,7 +238,9 @@ module "marklogic" {
     local.all_notifications_email_addresses,
     ["deltastatsupport@levellingup.gov.uk"]
   )
-  backup_replication_bucket = module.backup_replication_bucket.bucket
+  backup_replication_bucket          = module.backup_replication_bucket.bucket
+  ebs_backup_role_arn                = module.ebs_backup.role_arn
+  ebs_backup_completed_sns_topic_arn = module.ebs_backup.sns_topic_arn
 }
 
 module "gh_runner" {

--- a/terraform/test/main.tf
+++ b/terraform/test/main.tf
@@ -288,6 +288,28 @@ module "backup_replication_bucket" {
   object_expiration_days        = 30
 }
 
+module "ebs_backup" {
+  source = "../modules/ebs_backup"
+
+  environment                          = local.environment
+  ebs_backup_error_notification_emails = local.all_notifications_email_addresses
+}
+
+moved {
+  from = module.marklogic.aws_iam_role.ebs_backup
+  to   = module.ebs_backup.aws_iam_role.ebs_backup
+}
+
+moved {
+  from = module.marklogic.aws_iam_role_policy_attachment.service_backup
+  to   = module.ebs_backup.aws_iam_role_policy_attachment.service_backup
+}
+
+moved {
+  from = module.marklogic.aws_iam_role_policy_attachment.service_restore
+  to   = module.ebs_backup.aws_iam_role_policy_attachment.service_restore
+}
+
 module "marklogic" {
   source = "../modules/marklogic"
 
@@ -305,7 +327,6 @@ module "marklogic" {
     throughput_MiB_per_sec = 250
   }
 
-  ebs_backup_error_notification_emails    = local.all_notifications_email_addresses
   extra_instance_policy_arn               = data.aws_iam_policy.enable_session_manager.arn
   app_cloudwatch_log_expiration_days      = local.cloudwatch_log_expiration_days
   patch_cloudwatch_log_expiration_days    = local.patch_cloudwatch_log_expiration_days
@@ -317,6 +338,8 @@ module "marklogic" {
   dap_external_role_arns                  = var.dap_external_role_arns
   dap_job_notification_emails             = local.all_notifications_email_addresses
   backup_replication_bucket               = module.backup_replication_bucket.bucket
+  ebs_backup_role_arn                     = module.ebs_backup.role_arn
+  ebs_backup_completed_sns_topic_arn      = module.ebs_backup.sns_topic_arn
 }
 
 module "gh_runner" {


### PR DESCRIPTION
In preparation for sharing them with a new AWS Backup Vault for the new system volume backups.

This replaces the current MarkLogic-specific SNS topic, so we'll need to confirm the new subscription (which I've done for test)