### PR TITLE
DT-803 Update backup retention for weekly buckets

### DIFF
--- a/terraform/modules/marklogic/backup_buckets.tf
+++ b/terraform/modules/marklogic/backup_buckets.tf
@@ -52,7 +52,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "weekly_backup_bucket" {
     }
 
     noncurrent_version_expiration {
-      noncurrent_days = 20 # TODO DT-803 Reduce expiration once we have a full set of backups replicated
+      noncurrent_days = 7
     }
 
     status = "Enabled"
@@ -69,14 +69,8 @@ resource "aws_s3_bucket_lifecycle_configuration" "weekly_backup_bucket" {
         prefix = "${rule.value}/20"
       }
 
-      # TODO DT-803 Remove transition and reduce expiration once we have a full set of backups replicated
-      transition {
-        days          = 7
-        storage_class = "GLACIER_IR"
-      }
-
       expiration {
-        days = 80
+        days = 10
       }
 
       status = "Enabled"

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -178,7 +178,7 @@ module "backup_replication_bucket" {
 
   environment                   = local.environment
   s3_access_log_expiration_days = local.s3_log_expiration_days
-  compliance_retention_days     = 14 # TODO DT-742 Increase once happy with replication
+  compliance_retention_days     = 28
   object_expiration_days        = 90
 }
 

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -270,7 +270,7 @@ module "backup_replication_bucket" {
 
   environment                   = local.environment
   s3_access_log_expiration_days = local.s3_log_expiration_days
-  compliance_retention_days     = 1
+  compliance_retention_days     = 28
   object_expiration_days        = 30
 }
 


### PR DESCRIPTION
* Reduce the retention for the weekly backup source bucket as it should be replicated and we don't want to keep two copies 💸 
* Increase the object lock period on the replicated bucket, we're reasonably confident it works now

I'm reasonably sure this won't delete the objects in the bucket we replicate too:

> if lifecycle configuration is enabled only on your source bucket, Amazon S3 creates delete markers for expired objects but doesn't replicate those markers

<https://docs.aws.amazon.com/AmazonS3/latest/userguide/replication-what-is-isnot-replicated.html#replication-delete-op>

But we should keep an eye out on staging.