### PR TITLE
DT-997 Remove dluhc-preprod.uk as secondary domain for bastion

### DIFF
--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -135,8 +135,8 @@ module "bastion" {
   tags_asg                = var.default_tags
   tags_host_key           = { "terraform-plan-read" = true }
 
-  dns_config = {
-    zone_id = var.hosted_zone_id
+  dns_config = var.secondary_domain == null ? null : {
+    zone_id = var.secondary_domain_zone_id
     domain  = "bastion.${var.secondary_domain}"
   }
 }

--- a/terraform/production/variables.tf
+++ b/terraform/production/variables.tf
@@ -16,7 +16,12 @@ variable "primary_domain" {
 
 variable "secondary_domain" {
   type    = string
-  default = "dluhc-preprod.uk"
+  default = null
+}
+
+variable "secondary_domain_zone_id" {
+  type    = string
+  default = null
 }
 
 variable "allowed_ssh_cidrs" {
@@ -41,11 +46,6 @@ variable "github_actions_runner_token" {
 variable "jasper_s3_bucket" {
   type    = string
   default = "dluhc-jaspersoft-bin-prod"
-}
-
-variable "hosted_zone_id" {
-  type    = string
-  default = "Z05291902D4B4GXLXJDZQ"
 }
 
 variable "dap_external_role_arns" {

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -110,7 +110,7 @@ module "bastion" {
   extra_userdata          = file("${path.module}/../bastion_config.sh")
   tags_asg                = var.default_tags
   tags_host_key           = { "terraform-plan-read" = true }
-  dns_config = {
+  dns_config = var.secondary_domain == null ? null : {
     zone_id = var.secondary_domain_zone_id
     domain  = "bastion.${var.secondary_domain}"
   }


### PR DESCRIPTION
We no longer own `dluhc-preprod.uk`. It was only referenced by the bastion host anyway.

I haven't tried applying this since it's prod.

We should manually delete the hosted zone when this is released.