### PR TITLE
DT-803: Set weekly source backup retention to 60 days on production

### DIFF
--- a/terraform/modules/marklogic/backup_buckets.tf
+++ b/terraform/modules/marklogic/backup_buckets.tf
@@ -70,7 +70,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "weekly_backup_bucket" {
       }
 
       expiration {
-        days = 10
+        days = var.weekly_backup_bucket_retention_days
       }
 
       status = "Enabled"

--- a/terraform/modules/marklogic/variables.tf
+++ b/terraform/modules/marklogic/variables.tf
@@ -115,3 +115,9 @@ variable "backup_replication_bucket" {
     name = string
   })
 }
+
+variable "weekly_backup_bucket_retention_days" {
+  type        = number
+  default     = 10
+  description = "Number of days to keep weekly backups in their original bucket before adding a delete marker. The weekly backup bucket is replicated, so this shouldn't need to be very long."
+}

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -237,6 +237,8 @@ module "marklogic" {
   backup_replication_bucket          = module.backup_replication_bucket.bucket
   ebs_backup_role_arn                = module.ebs_backup.role_arn
   ebs_backup_completed_sns_topic_arn = module.ebs_backup.sns_topic_arn
+  # TODO DT-803 Reduce/remove this once we are happy with our testing on staging
+  weekly_backup_bucket_retention_days = 60
 }
 
 module "gh_runner" {


### PR DESCRIPTION
So that we can release this without having had a chance to thoroughly test it on staging. 60 is somewhat arbitrary, but if this somehow causes the replicated backups to be deleted it's enough history to keep (was originally 90 days).

I haven't tested or applied this anywhere, it should only affect production.