### PR TITLE
Give infra support permissions for autoscaling group instance refreshes

### DIFF
--- a/terraform/modules/iam_roles/policies.tf
+++ b/terraform/modules/iam_roles/policies.tf
@@ -225,8 +225,13 @@ resource "aws_iam_policy" "application_support" {
 # tfsec:ignore:aws-iam-no-policy-wildcards
 data "aws_iam_policy_document" "infra_support" {
   statement {
-    sid       = "UpdateAutoscalingGroups"
-    actions   = ["autoscaling:UpdateAutoScalingGroup"]
+    sid = "UpdateAutoscalingGroups"
+    actions = [
+      "autoscaling:UpdateAutoScalingGroup",
+      "autoscaling:CancelInstanceRefresh",
+      "autoscaling:RollbackInstanceRefresh",
+      "autoscaling:StartInstanceRefresh",
+    ]
     resources = ["*"]
   }
 


### PR DESCRIPTION
Since manually triggering one for Orbeon is part of the release process. I've checked it works on test.