### PR TITLE
DT-732 Changes required for auth service telemetry

### DIFF
--- a/terraform/modules/networking/ecr_interfaces.tf
+++ b/terraform/modules/networking/ecr_interfaces.tf
@@ -53,9 +53,8 @@ data "aws_iam_policy_document" "ecr_dkr_endpoint" {
       "ecr:BatchCheckLayerAvailability",
       "ecr:GetDownloadUrlForLayer",
       "ecr:BatchGetImage",
-      # For ECR Public pull through cache
-      "ecr:BatchImportUpstreamImage",
-      "ecr:CreateRepository",
+      "ecr:BatchImportUpstreamImage", # For ECR Public pull through cache
+      "ecr:CreateRepository",         # For ECR Public pull through cache
     ]
     principals {
       type        = "AWS"

--- a/terraform/modules/networking/ecr_interfaces.tf
+++ b/terraform/modules/networking/ecr_interfaces.tf
@@ -53,11 +53,17 @@ data "aws_iam_policy_document" "ecr_dkr_endpoint" {
       "ecr:BatchCheckLayerAvailability",
       "ecr:GetDownloadUrlForLayer",
       "ecr:BatchGetImage",
+      # For ECR Public pull through cache
+      "ecr:BatchImportUpstreamImage",
+      "ecr:CreateRepository",
     ]
     principals {
       type        = "AWS"
       identifiers = [data.aws_caller_identity.current.account_id]
     }
-    resources = ["arn:aws:ecr:${data.aws_region.current.name}:${var.ecr_repo_account_id}:*"]
+    resources = distinct([
+      "arn:aws:ecr:${data.aws_region.current.name}:${var.ecr_repo_account_id}:*",
+      "arn:aws:ecr:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:*"
+    ])
   }
 }

--- a/terraform/modules/networking/main.tf
+++ b/terraform/modules/networking/main.tf
@@ -115,8 +115,11 @@ locals {
       subnets              = aws_subnet.auth_service
       cidr                 = local.auth_service_cidr_10
       http_allowed_domains = []
-      tls_allowed_domains  = ["login.microsoftonline.com", "graph.microsoft.com"] // Microsoft domains for OAuth token endpoint and fetching user info
-      sid_offset           = 1300
+      tls_allowed_domains = [
+        "login.microsoftonline.com", "graph.microsoft.com", # Microsoft domains for OAuth token endpoint and fetching user info
+        "xray.${data.aws_region.current.name}.amazonaws.com",
+      ]
+      sid_offset = 1300
     }
     marklogic = {
       cidr                 = local.ml_subnet_cidr_10

--- a/terraform/production/ecr.tf
+++ b/terraform/production/ecr.tf
@@ -67,3 +67,9 @@ module "ecr" {
   repo_name = each.value["repo_name"]
   push_user = each.value["push_user"]
 }
+
+# Currently used by auth service for pulling AWS telemetry sidecar
+resource "aws_ecr_pull_through_cache_rule" "ecr_public" {
+  ecr_repository_prefix = "ecr-public"
+  upstream_registry_url = "public.ecr.aws"
+}

--- a/terraform/staging/ecr.tf
+++ b/terraform/staging/ecr.tf
@@ -1,5 +1,5 @@
 # Currently used by auth service for pulling AWS telemetry sidecar
-resource "aws_ecr_pull_through_cache_rule" "ecr_public2" {
+resource "aws_ecr_pull_through_cache_rule" "ecr_public" {
   ecr_repository_prefix = "ecr-public"
   upstream_registry_url = "public.ecr.aws"
 }

--- a/terraform/staging/ecr.tf
+++ b/terraform/staging/ecr.tf
@@ -1,0 +1,5 @@
+# Currently used by auth service for pulling AWS telemetry sidecar
+resource "aws_ecr_pull_through_cache_rule" "ecr_public2" {
+  ecr_repository_prefix = "ecr-public"
+  upstream_registry_url = "public.ecr.aws"
+}


### PR DESCRIPTION
ECR pull through cache rule so that access to ECR public (which needs *.cloudfront.net to be allowlisted to work 🤦) isn't required from within the VPC, plus associated changes to the VPC interface permissions.

Allow access to X-Ray from the auth service, I don't think there's any reason to use a VPC interface endpoint over allowing it through the firewall.