### PR TITLE
DT-753 Add sts to TLS allowlist for github runner

### DIFF
--- a/terraform/modules/networking/main.tf
+++ b/terraform/modules/networking/main.tf
@@ -27,6 +27,7 @@ locals {
         "objects.githubusercontent.com", "objects-origin.githubusercontent.com", "github-releases.githubusercontent.com", "github-registry-files.githubusercontent.com",
         ".actions.githubusercontent.com",
         "actions-results-receiver-production.githubapp.com",
+        "sts.eu-west-1.amazonaws.com", # For getting AWS credentials via OIDC
         # Custom rule for productionresultssa*.blob.core.windows.net in firewall.tf to support the wildcard
       ]
       sid_offset = 300


### PR DESCRIPTION
So the delta-marklogic-deploy jobs can use OIDC to authenticate to AWS