### PR TITLE
DT-1100 Rename "internal" subnet to fo-to-pdf

### DIFF
--- a/manual_scripts/active_directory/users-to-groups.csv
+++ b/manual_scripts/active_directory/users-to-groups.csv
@@ -6,7 +6,6 @@ datamart-delta-admin-dclg,deltaapp
 datamart-delta-user-dclg,deltaapp
 datamart-delta-marklogic-admin,deltaapp
 datamart-delta-marklogic-admin,jasperreports
-AWS Delegated Administrators,deltainternal
 datamart-delta-admin,deltaadmin
 datamart-delta-admin-dclg,deltaadmin
 datamart-delta-user,deltaadmin
@@ -22,6 +21,5 @@ dluhc-service-users,keycloak
 dluhc-service-users,cpmapp
 dluhc-service-users,sap
 dluhc-service-users,jasperreports
-dluhc-service-users,deltainternal
 dluhc-service-users,deltaapp
 dluhc-service-users,deltaorbeon

--- a/manual_scripts/active_directory/users.csv
+++ b/manual_scripts/active_directory/users.csv
@@ -1,7 +1,6 @@
 SamAccountName,Password,UserPrincipalName,DisplayName,GivenName,Surname,Email,Name,Path
 joebloggs,put password here,joe.bloggs@dluhcdata.local,Joe Bloggs,Joe,Bloggs,Group-DLUHCDeltaNotifications+joebloggs@softwire.com,joe.bloggs,"CN=Datamart,OU=Users,OU=dluhcdata,DC=dluhcdata,DC=local"
 deltaapp,put password here,delta.app@dluhcdata.local,Delta App,,,,delta.app,"OU=Users,OU=dluhcdata,DC=dluhcdata,DC=local"
-deltainternal,put password here,delta.internal@dluhcdata.local,Delta Internal App,,,,delta.internal,"CN=Datamart,OU=Users,OU=dluhcdata,DC=dluhcdata,DC=local"
 deltaadmin,put password here,delta.admin@dluhcdata.local,Delta Admin,Delta,Admin,delta.admin,delta.admin,"CN=Datamart,OU=Users,OU=dluhcdata,DC=dluhcdata,DC=local"
 deltauser,put password here,delta.user@dluhcdata.local,Delta User,Delta,User,delta.user,delta.user,"CN=Datamart,OU=Users,OU=dluhcdata,DC=dluhcdata,DC=local"
 reportuser,put password here,report.user@dluhcdata.local,Report User,,,,report.user,"CN=Datamart,OU=Users,OU=dluhcdata,DC=dluhcdata,DC=local"

--- a/terraform/modules/networking/main.tf
+++ b/terraform/modules/networking/main.tf
@@ -59,8 +59,8 @@ locals {
       ]
       sid_offset = 500
     }
-    delta_internal_subnets = {
-      cidr                 = local.delta_internal_cidr_10
+    delta_fo_to_pdf_subnets = {
+      cidr                 = local.delta_fo_to_pdf_cidr_10
       http_allowed_domains = []
       tls_allowed_domains  = []
       sid_offset           = 600
@@ -159,7 +159,7 @@ locals {
   firewalled_subnets = concat(
     aws_subnet.bastion_private_subnets,
     aws_subnet.ad_dc_private_subnets,
-    aws_subnet.delta_internal,
+    aws_subnet.delta_fo_to_pdf,
     aws_subnet.delta_api,
     aws_subnet.delta_website,
     aws_subnet.cpm_private,

--- a/terraform/modules/networking/outputs.tf
+++ b/terraform/modules/networking/outputs.tf
@@ -40,9 +40,9 @@ output "ml_restore_rehearsal_private_subnets" {
   description = "Three private /24 subnets for MarkLogic restore from backup rehearsal"
 }
 
-output "delta_internal_subnets" {
-  value       = aws_subnet.delta_internal
-  description = "Three private /24 subnets for internal Delta apps"
+output "delta_fo_to_pdf_subnets" {
+  value       = aws_subnet.delta_fo_to_pdf
+  description = "Three private /24 subnets for the fo-to-pdf Delta app"
 }
 
 output "delta_api_subnets" {

--- a/terraform/modules/networking/subnet.tf
+++ b/terraform/modules/networking/subnet.tf
@@ -9,7 +9,7 @@ locals {
   ad_other_cidr_10                    = cidrsubnet(aws_vpc.vpc.cidr_block, 6, 2)   # 8.0/22
   ml_subnet_cidr_10                   = cidrsubnet(aws_vpc.vpc.cidr_block, 6, 3)   # 12.0/22
   jaspersoft_cidr_10                  = cidrsubnet(aws_vpc.vpc.cidr_block, 6, 4)   # 16.0/22
-  delta_internal_cidr_10              = cidrsubnet(aws_vpc.vpc.cidr_block, 6, 5)   # 20.0/22
+  delta_fo_to_pdf_cidr_10             = cidrsubnet(aws_vpc.vpc.cidr_block, 6, 5)   # 20.0/22
   github_runner_cidr_10               = cidrsubnet(aws_vpc.vpc.cidr_block, 6, 6)   # 24.0/22
   delta_api_cidr_10                   = cidrsubnet(aws_vpc.vpc.cidr_block, 6, 7)   # 28.0/22
   cpm_private_cidr_10                 = cidrsubnet(aws_vpc.vpc.cidr_block, 6, 8)   # 32.0/22
@@ -87,13 +87,18 @@ resource "aws_subnet" "ml_restore_rehearsal_private_subnets" {
   tags                    = { Name = "ml-restore-test-private-subnet-${data.aws_availability_zones.available.names[count.index]}-${var.environment}" }
 }
 
-resource "aws_subnet" "delta_internal" {
+resource "aws_subnet" "delta_fo_to_pdf" {
   count                   = 3
-  cidr_block              = cidrsubnet(local.delta_internal_cidr_10, 2, count.index)
+  cidr_block              = cidrsubnet(local.delta_fo_to_pdf_cidr_10, 2, count.index)
   vpc_id                  = aws_vpc.vpc.id
   availability_zone       = data.aws_availability_zones.available.names[count.index]
   map_public_ip_on_launch = false
-  tags                    = { Name = "delta-internal-private-subnet-${data.aws_availability_zones.available.names[count.index]}-${var.environment}" }
+  tags                    = { Name = "delta-fo-to-pdf-private-subnet-${data.aws_availability_zones.available.names[count.index]}-${var.environment}" }
+}
+
+moved {
+  from = aws_subnet.delta_internal
+  to   = aws_subnet.delta_fo_to_pdf
 }
 
 resource "aws_subnet" "delta_api" {

--- a/terraform/production/outputs.tf
+++ b/terraform/production/outputs.tf
@@ -1,5 +1,10 @@
+# TODO Remove once no longer referenced by delta repo
 output "delta_internal_subnet_ids" {
-  value = module.networking.delta_internal_subnets[*].id
+  value = module.networking.delta_fo_to_pdf_subnets[*].id
+}
+
+output "delta_fo_to_pdf_subnet_ids" {
+  value = module.networking.delta_fo_to_pdf_subnets[*].id
 }
 
 output "delta_api_subnet_ids" {
@@ -138,11 +143,6 @@ output "security_sns_topic_global_arn" {
 
 output "deploy_user_kms_key_arn" {
   value = module.marklogic.deploy_user_kms_key_arn
-}
-
-# TODO: Remove once no longer used
-output "auth_listener_arn" {
-  value = module.public_albs.auth_alb_listener_arn
 }
 
 output "auth_internal_alb" {

--- a/terraform/staging/outputs.tf
+++ b/terraform/staging/outputs.tf
@@ -46,8 +46,13 @@ output "bastion_sg_id" {
   value = module.bastion.bastion_security_group_id
 }
 
+# TODO Remove once no longer referenced by delta repo
 output "delta_internal_subnet_ids" {
-  value = module.networking.delta_internal_subnets[*].id
+  value = module.networking.delta_fo_to_pdf_subnets[*].id
+}
+
+output "delta_fo_to_pdf_subnet_ids" {
+  value = module.networking.delta_fo_to_pdf_subnets[*].id
 }
 
 output "delta_api_subnet_ids" {
@@ -151,11 +156,6 @@ output "security_sns_topic_global_arn" {
 
 output "deploy_user_kms_key_arn" {
   value = module.marklogic.deploy_user_kms_key_arn
-}
-
-# TODO: Remove once no longer used
-output "auth_listener_arn" {
-  value = module.public_albs.auth_alb_listener_arn
 }
 
 output "auth_internal_alb" {

--- a/terraform/test/outputs.tf
+++ b/terraform/test/outputs.tf
@@ -70,10 +70,14 @@ output "bastion_sg_id" {
   value = module.bastion.bastion_security_group_id
 }
 
+# TODO Remove once no longer referenced by delta repo
 output "delta_internal_subnet_ids" {
-  value = module.networking.delta_internal_subnets[*].id
+  value = module.networking.delta_fo_to_pdf_subnets[*].id
 }
 
+output "delta_fo_to_pdf_subnet_ids" {
+  value = module.networking.delta_fo_to_pdf_subnets[*].id
+}
 output "delta_api_subnet_ids" {
   value = module.networking.delta_api_subnets[*].id
 }
@@ -166,11 +170,6 @@ output "security_sns_topic_global_arn" {
 
 output "deploy_user_kms_key_arn" {
   value = module.marklogic.deploy_user_kms_key_arn
-}
-
-# TODO: Remove once no longer used
-output "auth_listener_arn" {
-  value = module.public_albs.auth_alb_listener_arn
 }
 
 output "auth_internal_alb" {


### PR DESCRIPTION
Turns out it's used by fo-to-pdf so rename instead of removing. Will need a corresponding change in the Delta terraform, but I've left both outputs for now so it doesn't need to be done in order.

It will destroy and recreate the route tables with the new names, so technically this comes with downtime for fo-to-pdf, but it should only be a couple of seconds.

I've also removed reference to the deltainternal AD user, if it hasn't already I'll remove it from all environments when this is merged.