### PR TITLE
Increase sensitivity of auth client errors alarm

### DIFF
--- a/terraform/modules/cloudfront_alb_monitoring/main.tf
+++ b/terraform/modules/cloudfront_alb_monitoring/main.tf
@@ -13,7 +13,7 @@ module "website_cloudfront_alb_monitoring" {
 
   cloudfront_p90_origin_latency_high_alarm_threshold_ms     = 10000
   cloudfront_average_origin_latency_high_alarm_threshold_ms = 6000
-  alb_target_client_error_rate_alarm_threshold_percent      = 20
+  alb_target_client_error_rate_alarm_threshold_percent      = 30
 }
 
 module "api_cloudfront_alb_monitoring" {
@@ -41,7 +41,7 @@ module "keycloak_cloudfront_alb_monitoring" {
   enable_aws_shield_alarms      = var.enable_aws_shield_alarms
   prefix                        = "${var.environment}-keycloak"
 
-  alb_target_client_error_rate_alarm_threshold_count   = 15
+  alb_target_client_error_rate_alarm_threshold_count = 15
 }
 
 module "cpm_cloudfront_alb_monitoring" {

--- a/terraform/modules/cloudfront_alb_monitoring/main.tf
+++ b/terraform/modules/cloudfront_alb_monitoring/main.tf
@@ -40,6 +40,8 @@ module "keycloak_cloudfront_alb_monitoring" {
   security_sns_topic_global_arn = var.security_sns_topic_global_arn
   enable_aws_shield_alarms      = var.enable_aws_shield_alarms
   prefix                        = "${var.environment}-keycloak"
+
+  alb_target_client_error_rate_alarm_threshold_count   = 15
 }
 
 module "cpm_cloudfront_alb_monitoring" {


### PR DESCRIPTION
The default is 30. The recent API issue would be the only time this would have gone off in the last 4 weeks.

Also increase the % threshold for the website, Orbeon keeps setting it off.