### PR TITLE
DT-280 Change SES to use keys specific to application

### DIFF
--- a/terraform/modules/marklogic/deploy_user.tf
+++ b/terraform/modules/marklogic/deploy_user.tf
@@ -23,6 +23,34 @@ resource "aws_kms_alias" "ml_deploy_secrets" {
   target_key_id = aws_kms_key.ml_deploy_secrets.key_id
 }
 
+resource "aws_kms_key" "cpm_ml_deploy_secrets" {
+  description         = "cpm-ses-deploy-secrets-${var.environment}"
+  enable_key_rotation = true
+
+  tags = {
+    "terraform-plan-read" = true
+  }
+}
+
+resource "aws_kms_alias" "cpm_ml_deploy_secrets" {
+  name          = "alias/cpm-ses-deploy-secrets-${var.environment}"
+  target_key_id = aws_kms_key.cpm_ml_deploy_secrets.key_id
+}
+
+resource "aws_kms_key" "delta_ml_deploy_secrets" {
+  description         = "delta-ses-deploy-secrets-${var.environment}"
+  enable_key_rotation = true
+
+  tags = {
+    "terraform-plan-read" = true
+  }
+}
+
+resource "aws_kms_alias" "delta_ml_deploy_secrets" {
+  name          = "alias/delta-ses-deploy-secrets-${var.environment}"
+  target_key_id = aws_kms_key.delta_ml_deploy_secrets.key_id
+}
+
 data "aws_secretsmanager_secret" "ml_admin_user" {
   name = "ml-admin-user-${var.environment}"
 

--- a/terraform/modules/marklogic/deploy_user.tf
+++ b/terraform/modules/marklogic/deploy_user.tf
@@ -23,33 +23,6 @@ resource "aws_kms_alias" "ml_deploy_secrets" {
   target_key_id = aws_kms_key.ml_deploy_secrets.key_id
 }
 
-resource "aws_kms_key" "cpm_ml_deploy_secrets" {
-  description         = "cpm-ses-deploy-secrets-${var.environment}"
-  enable_key_rotation = true
-
-  tags = {
-    "terraform-plan-read" = true
-  }
-}
-
-resource "aws_kms_alias" "cpm_ml_deploy_secrets" {
-  name          = "alias/cpm-ses-deploy-secrets-${var.environment}"
-  target_key_id = aws_kms_key.cpm_ml_deploy_secrets.key_id
-}
-
-resource "aws_kms_key" "delta_ml_deploy_secrets" {
-  description         = "delta-ses-deploy-secrets-${var.environment}"
-  enable_key_rotation = true
-
-  tags = {
-    "terraform-plan-read" = true
-  }
-}
-
-resource "aws_kms_alias" "delta_ml_deploy_secrets" {
-  name          = "alias/delta-ses-deploy-secrets-${var.environment}"
-  target_key_id = aws_kms_key.delta_ml_deploy_secrets.key_id
-}
 
 data "aws_secretsmanager_secret" "ml_admin_user" {
   name = "ml-admin-user-${var.environment}"
@@ -94,6 +67,11 @@ data "aws_iam_policy_document" "read_marklogic_deploy_secrets" {
     actions   = ["kms:DescribeKey", "kms:Decrypt"]
     effect    = "Allow"
     resources = [aws_kms_key.ml_deploy_secrets.arn]
+  }
+  statement {
+    actions   = ["kms:DescribeKey", "kms:Decrypt"]
+    effect    = "Allow"
+    resources = var.ses_deploy_secret_arns
   }
   statement {
     actions   = ["secretsmanager:ListSecrets"]

--- a/terraform/modules/marklogic/outputs.tf
+++ b/terraform/modules/marklogic/outputs.tf
@@ -15,14 +15,6 @@ output "deploy_user_kms_key_arn" {
   value = aws_kms_key.ml_deploy_secrets.arn
 }
 
-output "deploy_user_cpm_kms_key_arn" {
-  value = aws_kms_key.cpm_ml_deploy_secrets.arn
-}
-
-output "deploy_user_delta_kms_key_arn" {
-  value = aws_kms_key.delta_ml_deploy_secrets.arn
-}
-
 output "instance_iam_role" {
   value = aws_iam_role.ml_iam_role.name
 }

--- a/terraform/modules/marklogic/outputs.tf
+++ b/terraform/modules/marklogic/outputs.tf
@@ -15,6 +15,14 @@ output "deploy_user_kms_key_arn" {
   value = aws_kms_key.ml_deploy_secrets.arn
 }
 
+output "deploy_user_cpm_kms_key_arn" {
+  value = aws_kms_key.cpm_ml_deploy_secrets.arn
+}
+
+output "deploy_user_delta_kms_key_arn" {
+  value = aws_kms_key.delta_ml_deploy_secrets.arn
+}
+
 output "instance_iam_role" {
   value = aws_iam_role.ml_iam_role.name
 }

--- a/terraform/modules/marklogic/variables.tf
+++ b/terraform/modules/marklogic/variables.tf
@@ -125,3 +125,8 @@ variable "weekly_backup_bucket_retention_days" {
 variable "iam_github_openid_connect_provider_arn" {
   type = string
 }
+
+variable "ses_deploy_secret_arns" {
+  type        = list(string)
+  description = "List of arns of the kms keys for SES credentials"
+}

--- a/terraform/modules/ses_user/main.tf
+++ b/terraform/modules/ses_user/main.tf
@@ -80,7 +80,6 @@ output "smtp_password" {
   sensitive = true
 }
 
-output "deploy_secret_arn"
-{
+output "deploy_secret_arn" {
   value   = aws_kms_key.deploy_secrets.arn
 }

--- a/terraform/modules/ses_user/main.tf
+++ b/terraform/modules/ses_user/main.tf
@@ -81,5 +81,5 @@ output "smtp_password" {
 }
 
 output "deploy_secret_arn" {
-  value   = aws_kms_key.deploy_secrets.arn
+  value = aws_kms_key.deploy_secrets.arn
 }

--- a/terraform/modules/ses_user/secret.tf
+++ b/terraform/modules/ses_user/secret.tf
@@ -1,7 +1,7 @@
 resource "aws_secretsmanager_secret" "ses_user" {
   name                    = "tf-smtp-${var.username}"
   description             = "Managed by Terraform, do not update manually"
-  kms_key_id              = var.kms_key_arn
+  kms_key_id              = aws_kms_key.deploy_secrets.arn
   recovery_window_in_days = 0
 
   tags = {

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -79,7 +79,6 @@ module "delta_ses_user" {
   ses_identity_arns     = [module.ses_identity.arn, module.ses_identity_communities.arn]
   from_address_patterns = ["delta@datacollection.levellingup.gov.uk", "delta@datacollection.communities.gov.uk"]
   environment           = local.environment
-  kms_key_arn           = module.marklogic.deploy_user_delta_kms_key_arn
   vpc_id                = module.networking.vpc.id
 }
 
@@ -89,7 +88,6 @@ module "cpm_ses_user" {
   ses_identity_arns     = [module.ses_identity.arn, module.ses_identity_communities.arn]
   from_address_patterns = ["cpm@datacollection.levellingup.gov.uk", "cpm@datacollection.communities.gov.uk"]
   environment           = local.environment
-  kms_key_arn           = module.marklogic.deploy_user_cpm_kms_key_arn
   vpc_id                = module.networking.vpc.id
 }
 

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -248,7 +248,7 @@ module "marklogic" {
   # TODO DT-803 Reduce/remove this once we are happy with our testing on staging
   weekly_backup_bucket_retention_days    = 60
   iam_github_openid_connect_provider_arn = module.github_actions_openid_connect_provider.github_oidc_provider_arn
-  ses_deploy_secret_arns                  = [module.delta_ses_user.deploy_secret_arn, module.cpm_ses_user.deploy_secret_arn]
+  ses_deploy_secret_arns                 = [module.delta_ses_user.deploy_secret_arn, module.cpm_ses_user.deploy_secret_arn]
 }
 
 module "gh_runner" {

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -79,7 +79,7 @@ module "delta_ses_user" {
   ses_identity_arns     = [module.ses_identity.arn, module.ses_identity_communities.arn]
   from_address_patterns = ["delta@datacollection.levellingup.gov.uk", "delta@datacollection.communities.gov.uk"]
   environment           = local.environment
-  kms_key_arn           = module.marklogic.deploy_user_kms_key_arn
+  kms_key_arn           = module.marklogic.deploy_user_delta_kms_key_arn
   vpc_id                = module.networking.vpc.id
 }
 
@@ -89,7 +89,7 @@ module "cpm_ses_user" {
   ses_identity_arns     = [module.ses_identity.arn, module.ses_identity_communities.arn]
   from_address_patterns = ["cpm@datacollection.levellingup.gov.uk", "cpm@datacollection.communities.gov.uk"]
   environment           = local.environment
-  kms_key_arn           = module.marklogic.deploy_user_kms_key_arn
+  kms_key_arn           = module.marklogic.deploy_user_cpm_kms_key_arn
   vpc_id                = module.networking.vpc.id
 }
 

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -250,6 +250,7 @@ module "marklogic" {
   # TODO DT-803 Reduce/remove this once we are happy with our testing on staging
   weekly_backup_bucket_retention_days    = 60
   iam_github_openid_connect_provider_arn = module.github_actions_openid_connect_provider.github_oidc_provider_arn
+  ses_deploy_secret_arns                  = [module.delta_ses_user.deploy_secret_arn, module.cpm_ses_user.deploy_secret_arn]
 }
 
 module "gh_runner" {

--- a/terraform/production/outputs.tf
+++ b/terraform/production/outputs.tf
@@ -144,6 +144,10 @@ output "deploy_user_kms_key_arn" {
   value = module.marklogic.deploy_user_kms_key_arn
 }
 
+output "deploy_user_delta_kms_key_arn" {
+  value = module.delta_ses_user.deploy_secret_arn
+}
+
 output "auth_internal_alb" {
   value = module.auth_internal_alb.alb
 }

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -321,7 +321,8 @@ module "marklogic" {
   backup_replication_bucket               = module.backup_replication_bucket.bucket
   ebs_backup_role_arn                     = module.ebs_backup.role_arn
   ebs_backup_completed_sns_topic_arn      = module.ebs_backup.sns_topic_arn
-  iam_github_openid_connect_provider_arn  = data.aws_iam_openid_connect_provider.github.arn
+  iam_github_openid_connect_provider_arn  = data.aws_iam_openid_connect_provider.github.arn,
+  ses_deploy_secret_arns                  = [module.delta_ses_user.deploy_secret_arn, module.cpm_ses_user.deploy_secret_arn]
 }
 
 module "gh_runner" {
@@ -400,7 +401,6 @@ module "delta_ses_user" {
   ses_identity_arns     = [module.ses_identity.arn, module.ses_identity_communities.arn]
   from_address_patterns = ["delta-staging@datacollection.test.levellingup.gov.uk", "delta-staging@datacollection.test.communities.gov.uk"]
   environment           = local.environment
-  kms_key_arn           = module.marklogic.deploy_user_kms_key_arn
   vpc_id                = module.networking.vpc.id
 }
 
@@ -410,7 +410,6 @@ module "cpm_ses_user" {
   ses_identity_arns     = [module.ses_identity.arn, module.ses_identity_communities.arn]
   from_address_patterns = ["cpm-staging@datacollection.test.levellingup.gov.uk", "cpm-staging@datacollection.test.communities.gov.uk"]
   environment           = local.environment
-  kms_key_arn           = module.marklogic.deploy_user_kms_key_arn
   vpc_id                = module.networking.vpc.id
 }
 

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -321,7 +321,7 @@ module "marklogic" {
   backup_replication_bucket               = module.backup_replication_bucket.bucket
   ebs_backup_role_arn                     = module.ebs_backup.role_arn
   ebs_backup_completed_sns_topic_arn      = module.ebs_backup.sns_topic_arn
-  iam_github_openid_connect_provider_arn  = data.aws_iam_openid_connect_provider.github.arn,
+  iam_github_openid_connect_provider_arn  = data.aws_iam_openid_connect_provider.github.arn
   ses_deploy_secret_arns                  = [module.delta_ses_user.deploy_secret_arn, module.cpm_ses_user.deploy_secret_arn]
 }
 

--- a/terraform/staging/outputs.tf
+++ b/terraform/staging/outputs.tf
@@ -153,6 +153,10 @@ output "deploy_user_kms_key_arn" {
   value = module.marklogic.deploy_user_kms_key_arn
 }
 
+output "deploy_user_delta_kms_key_arn" {
+  value = module.delta_ses_user.deploy_secret_arn
+}
+
 output "auth_internal_alb" {
   value = module.auth_internal_alb.alb
 }

--- a/terraform/test/main.tf
+++ b/terraform/test/main.tf
@@ -406,7 +406,6 @@ module "ses_user" {
   ses_identity_arns     = [module.ses_identity.arn]
   from_address_patterns = ["*@datacollection.dluhc-dev.uk"]
   environment           = local.environment
-  kms_key_arn           = null
   vpc_id                = module.networking.vpc.id
 }
 

--- a/terraform/test/main.tf
+++ b/terraform/test/main.tf
@@ -327,6 +327,7 @@ module "marklogic" {
   ebs_backup_role_arn                     = module.ebs_backup.role_arn
   ebs_backup_completed_sns_topic_arn      = module.ebs_backup.sns_topic_arn
   iam_github_openid_connect_provider_arn  = module.github_actions_openid_connect_provider.github_oidc_provider_arn
+  ses_deploy_secret_arns                  = []
 }
 
 module "gh_runner" {


### PR DESCRIPTION
DT-280 SES users are now encrypted with keys specific to Delta and CPM.

Opening this PR for you, because you moved the ticket to ready for review but didn't create a PR?