### PR TITLE
DT-2437: Updated swap space alarm threshold to 2%

### DIFF
--- a/terraform/modules/marklogic/monitoring_alarms.tf
+++ b/terraform/modules/marklogic/monitoring_alarms.tf
@@ -248,7 +248,7 @@ resource "aws_cloudwatch_metric_alarm" "swap_usage_high" {
   namespace           = "${var.environment}/MarkLogic"
   period              = 300
   statistic           = "Maximum"
-  threshold           = 1
+  threshold           = 2
 
   alarm_description  = <<EOT
   Swap usage percentage is higher than expected.


### PR DESCRIPTION
Due to increased amount of alarms for relatively low swap space utilisation we have decided to increase the threshold to 2% to try to reduce the amount of times these alarms occur.