### PR TITLE
DT-2563: allow DAP access to bucket from IP using key/secret

### DIFF
--- a/terraform/modules/marklogic/dap_export_s3.tf
+++ b/terraform/modules/marklogic/dap_export_s3.tf
@@ -238,13 +238,12 @@ resource "aws_security_group" "dap_export_secret_rotation_lambda" {
   description = "Security group for DAP export secret rotation Lambda"
   vpc_id      = var.vpc.id
 
-  # tfsec:ignore:aws-vpc-no-public-egress-sgr
   egress {
-    description = "Allow HTTPS egress"
+    description = "Allow HTTPS egress within the VPC"
     from_port   = 443
     to_port     = 443
     protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
+    cidr_blocks = [var.vpc.cidr_block]
   }
 }
 

--- a/terraform/modules/marklogic/dap_export_s3.tf
+++ b/terraform/modules/marklogic/dap_export_s3.tf
@@ -1,6 +1,9 @@
 locals {
   delta_export_path                    = "/delta/export"
   latest_export_files_lifespan_in_days = 30
+  dap_export_external_access = {
+    for access in var.dap_export_external_access : access.name => access
+  }
 }
 
 module "dap_export_bucket" {
@@ -64,6 +67,166 @@ data "aws_iam_policy_document" "allow_access_from_dap" {
       ]
     }
   }
+}
+
+resource "time_rotating" "dap_export_external_iam_user" {
+  for_each = local.dap_export_external_access
+
+  rotation_days = each.value.rotation_days
+}
+
+resource "aws_iam_user" "dap_export_external" {
+  for_each = local.dap_export_external_access
+
+  name = "${each.key}-dap-export-${var.environment}"
+
+  lifecycle {
+    ignore_changes = [tags, tags_all] # AWS uses tags for access key descriptions
+  }
+}
+
+resource "aws_iam_access_key" "dap_export_external" {
+  for_each = local.dap_export_external_access
+
+  user = aws_iam_user.dap_export_external[each.key].name
+
+  lifecycle {
+    replace_triggered_by = [
+      time_rotating.dap_export_external_iam_user[each.key].id
+    ]
+  }
+}
+
+data "aws_iam_policy_document" "dap_export_external" {
+  for_each = local.dap_export_external_access
+
+  statement {
+    sid = "AllowLatestObjectReadFromApprovedIps"
+    actions = [
+      "s3:GetObject",
+    ]
+    resources = [
+      "${module.dap_export_bucket.bucket_arn}/latest/*",
+    ]
+
+    condition {
+      test     = "IpAddress"
+      variable = "aws:SourceIp"
+      values   = each.value.allowed_cidrs
+    }
+  }
+
+  statement {
+    sid = "AllowBucketMetadataReadFromApprovedIps"
+    actions = [
+      "s3:GetBucketLocation",
+      "s3:GetEncryptionConfiguration",
+    ]
+    resources = [
+      module.dap_export_bucket.bucket_arn,
+    ]
+
+    condition {
+      test     = "IpAddress"
+      variable = "aws:SourceIp"
+      values   = each.value.allowed_cidrs
+    }
+  }
+
+  statement {
+    sid = "AllowLatestBucketListFromApprovedIps"
+    actions = [
+      "s3:ListBucket",
+    ]
+    resources = [
+      module.dap_export_bucket.bucket_arn,
+    ]
+
+    condition {
+      test     = "IpAddress"
+      variable = "aws:SourceIp"
+      values   = each.value.allowed_cidrs
+    }
+
+    condition {
+      test     = "StringLike"
+      variable = "s3:prefix"
+      values = [
+        "latest",
+        "latest/*",
+      ]
+    }
+  }
+
+  statement {
+    sid    = "DenyS151ObjectRead"
+    effect = "Deny"
+    actions = [
+      "s3:GetObject",
+    ]
+    resources = [
+      "${module.dap_export_bucket.bucket_arn}/latest/s151*",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "dap_export_external" {
+  for_each = local.dap_export_external_access
+
+  name        = "${each.key}-dap-export-${var.environment}"
+  description = "Allows ${each.key} to read non-S151 DAP export objects"
+  policy      = data.aws_iam_policy_document.dap_export_external[each.key].json
+}
+
+resource "aws_iam_user_policy_attachment" "dap_export_external" {
+  for_each = local.dap_export_external_access
+
+  user       = aws_iam_user.dap_export_external[each.key].name
+  policy_arn = aws_iam_policy.dap_export_external[each.key].arn
+}
+
+resource "aws_kms_key" "dap_export_external_secret" {
+  for_each = local.dap_export_external_access
+
+  description         = "dap-export-${each.key}-${var.environment}"
+  enable_key_rotation = true
+
+  tags = {
+    "terraform-plan-read" = true
+  }
+}
+
+resource "aws_kms_alias" "dap_export_external_secret" {
+  for_each = local.dap_export_external_access
+
+  name          = "alias/dap-export-${each.key}-${var.environment}"
+  target_key_id = aws_kms_key.dap_export_external_secret[each.key].key_id
+}
+
+resource "aws_secretsmanager_secret" "dap_export_external" {
+  for_each = local.dap_export_external_access
+
+  name                    = "tf-dap-export-${each.key}-${var.environment}"
+  description             = "Managed by Terraform, do not update manually"
+  kms_key_id              = aws_kms_key.dap_export_external_secret[each.key].arn
+  recovery_window_in_days = 0
+
+  tags = {
+    "terraform-plan-read" = true
+  }
+}
+
+resource "aws_secretsmanager_secret_version" "dap_export_external" {
+  for_each = local.dap_export_external_access
+
+  secret_id = aws_secretsmanager_secret.dap_export_external[each.key].id
+  secret_string = jsonencode({
+    access_key_id     = aws_iam_access_key.dap_export_external[each.key].id
+    secret_access_key = aws_iam_access_key.dap_export_external[each.key].secret
+    region            = data.aws_region.current.name
+    bucket            = module.dap_export_bucket.bucket
+    prefix            = "latest/"
+  })
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "dap_export" {

--- a/terraform/modules/marklogic/dap_export_s3.tf
+++ b/terraform/modules/marklogic/dap_export_s3.tf
@@ -4,6 +4,7 @@ locals {
   dap_export_external_access = {
     for access in var.dap_export_external_access : access.name => access
   }
+  dap_export_rotation_lambda_subnets = var.dap_export_rotation_lambda_subnets == null ? var.private_subnets : var.dap_export_rotation_lambda_subnets
 }
 
 module "dap_export_bucket" {
@@ -150,6 +151,26 @@ data "aws_iam_policy_document" "dap_export_external" {
       "${module.dap_export_bucket.bucket_arn}/latest/s151*",
     ]
   }
+
+  statement {
+    sid    = "DenyS151BucketList"
+    effect = "Deny"
+    actions = [
+      "s3:ListBucket",
+    ]
+    resources = [
+      module.dap_export_bucket.bucket_arn,
+    ]
+
+    condition {
+      test     = "StringLike"
+      variable = "s3:prefix"
+      values = [
+        "latest/s151",
+        "latest/s151*",
+      ]
+    }
+  }
 }
 
 resource "aws_iam_policy" "dap_export_external" {
@@ -239,11 +260,11 @@ resource "aws_security_group" "dap_export_secret_rotation_lambda" {
   vpc_id      = var.vpc.id
 
   egress {
-    description = "Allow HTTPS egress within the VPC"
+    description = "Allow HTTPS egress to AWS APIs"
     from_port   = 443
     to_port     = 443
     protocol    = "tcp"
-    cidr_blocks = [var.vpc.cidr_block]
+    cidr_blocks = ["0.0.0.0/0"]
   }
 }
 
@@ -358,7 +379,7 @@ resource "aws_lambda_function" "dap_export_secret_rotation" {
   }
 
   vpc_config {
-    subnet_ids         = var.private_subnets[*].id
+    subnet_ids         = local.dap_export_rotation_lambda_subnets[*].id
     security_group_ids = [aws_security_group.dap_export_secret_rotation_lambda[each.key].id]
   }
 

--- a/terraform/modules/marklogic/dap_export_s3.tf
+++ b/terraform/modules/marklogic/dap_export_s3.tf
@@ -345,6 +345,8 @@ resource "aws_lambda_function" "dap_export_secret_rotation" {
   runtime = "python3.12"
   timeout = 60
 
+  kms_key_arn = aws_kms_key.dap_export_external_secret[each.key].arn
+
   environment {
     variables = {
       AWS_REGION_NAME   = data.aws_region.current.name

--- a/terraform/modules/marklogic/dap_export_s3.tf
+++ b/terraform/modules/marklogic/dap_export_s3.tf
@@ -259,6 +259,7 @@ resource "aws_security_group" "dap_export_secret_rotation_lambda" {
   description = "Security group for DAP export secret rotation Lambda"
   vpc_id      = var.vpc.id
 
+  # tfsec:ignore:aws-vpc-no-public-egress-sgr
   egress {
     description = "Allow HTTPS egress to AWS APIs"
     from_port   = 443

--- a/terraform/modules/marklogic/dap_export_s3.tf
+++ b/terraform/modules/marklogic/dap_export_s3.tf
@@ -345,7 +345,8 @@ resource "aws_lambda_function" "dap_export_secret_rotation" {
   runtime = "python3.12"
   timeout = 60
 
-  kms_key_arn = aws_kms_key.dap_export_external_secret[each.key].arn
+  kms_key_arn                    = aws_kms_key.dap_export_external_secret[each.key].arn
+  reserved_concurrent_executions = 1
 
   environment {
     variables = {

--- a/terraform/modules/marklogic/dap_export_s3.tf
+++ b/terraform/modules/marklogic/dap_export_s3.tf
@@ -69,12 +69,6 @@ data "aws_iam_policy_document" "allow_access_from_dap" {
   }
 }
 
-resource "time_rotating" "dap_export_external_iam_user" {
-  for_each = local.dap_export_external_access
-
-  rotation_days = each.value.rotation_days
-}
-
 resource "aws_iam_user" "dap_export_external" {
   for_each = local.dap_export_external_access
 
@@ -82,18 +76,6 @@ resource "aws_iam_user" "dap_export_external" {
 
   lifecycle {
     ignore_changes = [tags, tags_all] # AWS uses tags for access key descriptions
-  }
-}
-
-resource "aws_iam_access_key" "dap_export_external" {
-  for_each = local.dap_export_external_access
-
-  user = aws_iam_user.dap_export_external[each.key].name
-
-  lifecycle {
-    replace_triggered_by = [
-      time_rotating.dap_export_external_iam_user[each.key].id
-    ]
   }
 }
 
@@ -221,12 +203,168 @@ resource "aws_secretsmanager_secret_version" "dap_export_external" {
 
   secret_id = aws_secretsmanager_secret.dap_export_external[each.key].id
   secret_string = jsonencode({
-    access_key_id     = aws_iam_access_key.dap_export_external[each.key].id
-    secret_access_key = aws_iam_access_key.dap_export_external[each.key].secret
+    access_key_id     = ""
+    secret_access_key = ""
     region            = data.aws_region.current.name
     bucket            = module.dap_export_bucket.bucket
     prefix            = "latest/"
   })
+
+  lifecycle {
+    ignore_changes = [secret_string]
+  }
+}
+
+data "archive_file" "dap_export_secret_rotation" {
+  type        = "zip"
+  source_file = "${path.module}/dap_export_secret_rotation.py"
+  output_path = "${path.module}/dap_export_secret_rotation.zip"
+}
+
+module "dap_export_secret_rotation_log_group" {
+  for_each = local.dap_export_external_access
+
+  source         = "../encrypted_log_groups"
+  retention_days = var.patch_cloudwatch_log_expiration_days
+
+  kms_key_alias_name = "dap-export-secret-rotation-${each.key}-${var.environment}"
+  log_group_names    = ["/aws/lambda/dap-export-secret-rotation-${each.key}-${var.environment}"]
+}
+
+resource "aws_iam_role" "dap_export_secret_rotation" {
+  for_each = local.dap_export_external_access
+
+  name = "dap-export-secret-rotation-${each.key}-${var.environment}"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "lambda.amazonaws.com"
+        }
+      },
+    ]
+  })
+}
+
+data "aws_iam_policy_document" "dap_export_secret_rotation" {
+  for_each = local.dap_export_external_access
+
+  statement {
+    actions = [
+      "logs:CreateLogStream",
+      "logs:DescribeLogStreams",
+      "logs:PutLogEvents",
+    ]
+    resources = ["${module.dap_export_secret_rotation_log_group[each.key].log_group_arns[0]}:*"]
+  }
+
+  statement {
+    actions = [
+      "iam:CreateAccessKey",
+      "iam:DeleteAccessKey",
+      "iam:ListAccessKeys",
+    ]
+    resources = [aws_iam_user.dap_export_external[each.key].arn]
+  }
+
+  statement {
+    actions = [
+      "secretsmanager:DescribeSecret",
+      "secretsmanager:GetSecretValue",
+      "secretsmanager:PutSecretValue",
+      "secretsmanager:UpdateSecretVersionStage",
+    ]
+    resources = [aws_secretsmanager_secret.dap_export_external[each.key].arn]
+  }
+
+  statement {
+    actions = [
+      "kms:Decrypt",
+      "kms:DescribeKey",
+      "kms:Encrypt",
+      "kms:GenerateDataKey",
+    ]
+    resources = [
+      aws_kms_key.dap_export_external_secret[each.key].arn,
+      module.dap_export_secret_rotation_log_group[each.key].kms_key_arn,
+    ]
+  }
+}
+
+resource "aws_iam_policy" "dap_export_secret_rotation" {
+  for_each = local.dap_export_external_access
+
+  name        = "dap-export-secret-rotation-${each.key}-${var.environment}"
+  description = "Allows rotation of DAP export access keys for ${each.key}"
+  policy      = data.aws_iam_policy_document.dap_export_secret_rotation[each.key].json
+}
+
+resource "aws_iam_role_policy_attachment" "dap_export_secret_rotation" {
+  for_each = local.dap_export_external_access
+
+  role       = aws_iam_role.dap_export_secret_rotation[each.key].name
+  policy_arn = aws_iam_policy.dap_export_secret_rotation[each.key].arn
+}
+
+resource "aws_lambda_function" "dap_export_secret_rotation" {
+  for_each = local.dap_export_external_access
+
+  function_name    = "dap-export-secret-rotation-${each.key}-${var.environment}"
+  filename         = data.archive_file.dap_export_secret_rotation.output_path
+  source_code_hash = data.archive_file.dap_export_secret_rotation.output_base64sha256
+
+  role    = aws_iam_role.dap_export_secret_rotation[each.key].arn
+  handler = "dap_export_secret_rotation.lambda_handler"
+  runtime = "python3.12"
+  timeout = 60
+
+  environment {
+    variables = {
+      AWS_REGION_NAME   = data.aws_region.current.name
+      DAP_EXPORT_BUCKET = module.dap_export_bucket.bucket
+      DAP_EXPORT_PREFIX = "latest/"
+      IAM_USER_NAME     = aws_iam_user.dap_export_external[each.key].name
+    }
+  }
+
+  tracing_config {
+    mode = "Active"
+  }
+
+  depends_on = [
+    aws_iam_role_policy_attachment.dap_export_secret_rotation,
+    module.dap_export_secret_rotation_log_group,
+  ]
+}
+
+resource "aws_lambda_permission" "allow_secretsmanager_dap_export_rotation" {
+  for_each = local.dap_export_external_access
+
+  statement_id  = "AllowSecretsManagerRotation"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.dap_export_secret_rotation[each.key].function_name
+  principal     = "secretsmanager.amazonaws.com"
+  source_arn    = aws_secretsmanager_secret.dap_export_external[each.key].arn
+}
+
+resource "aws_secretsmanager_secret_rotation" "dap_export_external" {
+  for_each = local.dap_export_external_access
+
+  secret_id           = aws_secretsmanager_secret.dap_export_external[each.key].id
+  rotation_lambda_arn = aws_lambda_function.dap_export_secret_rotation[each.key].arn
+
+  rotation_rules {
+    automatically_after_days = each.value.rotation_days
+  }
+
+  depends_on = [
+    aws_lambda_permission.allow_secretsmanager_dap_export_rotation,
+    aws_secretsmanager_secret_version.dap_export_external,
+  ]
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "dap_export" {

--- a/terraform/modules/marklogic/dap_export_s3.tf
+++ b/terraform/modules/marklogic/dap_export_s3.tf
@@ -231,6 +231,23 @@ module "dap_export_secret_rotation_log_group" {
   log_group_names    = ["/aws/lambda/dap-export-secret-rotation-${each.key}-${var.environment}"]
 }
 
+resource "aws_security_group" "dap_export_secret_rotation_lambda" {
+  for_each = local.dap_export_external_access
+
+  name        = "dap-export-secret-rotation-${each.key}-${var.environment}"
+  description = "Security group for DAP export secret rotation Lambda"
+  vpc_id      = var.vpc.id
+
+  # tfsec:ignore:aws-vpc-no-public-egress-sgr
+  egress {
+    description = "Allow HTTPS egress"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
 resource "aws_iam_role" "dap_export_secret_rotation" {
   for_each = local.dap_export_external_access
 
@@ -310,6 +327,13 @@ resource "aws_iam_role_policy_attachment" "dap_export_secret_rotation" {
   policy_arn = aws_iam_policy.dap_export_secret_rotation[each.key].arn
 }
 
+resource "aws_iam_role_policy_attachment" "dap_export_secret_rotation_vpc_access" {
+  for_each = local.dap_export_external_access
+
+  role       = aws_iam_role.dap_export_secret_rotation[each.key].name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
+}
+
 resource "aws_lambda_function" "dap_export_secret_rotation" {
   for_each = local.dap_export_external_access
 
@@ -331,12 +355,18 @@ resource "aws_lambda_function" "dap_export_secret_rotation" {
     }
   }
 
+  vpc_config {
+    subnet_ids         = var.private_subnets[*].id
+    security_group_ids = [aws_security_group.dap_export_secret_rotation_lambda[each.key].id]
+  }
+
   tracing_config {
     mode = "Active"
   }
 
   depends_on = [
     aws_iam_role_policy_attachment.dap_export_secret_rotation,
+    aws_iam_role_policy_attachment.dap_export_secret_rotation_vpc_access,
     module.dap_export_secret_rotation_log_group,
   ]
 }

--- a/terraform/modules/marklogic/dap_export_secret_rotation.py
+++ b/terraform/modules/marklogic/dap_export_secret_rotation.py
@@ -1,7 +1,11 @@
 import json
+import logging
 import os
 
 import boto3
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
 
 iam = boto3.client("iam")
 secretsmanager = boto3.client("secretsmanager")
@@ -11,15 +15,19 @@ def lambda_handler(event, context):
     arn = event["SecretId"]
     token = event["ClientRequestToken"]
     step = event["Step"]
+    logger.info("Starting rotation step %s for secret %s", step, arn)
 
+    logger.info("Describing secret rotation metadata")
     metadata = secretsmanager.describe_secret(SecretId=arn)
     if not metadata.get("RotationEnabled"):
         raise ValueError(f"Secret {arn} is not enabled for rotation")
 
     version_stages = metadata["VersionIdsToStages"].get(token)
+    logger.info("Rotation token has stages: %s", version_stages)
     if version_stages is None:
         raise ValueError(f"Secret version {token} has no stage for {arn}")
     if "AWSCURRENT" in version_stages:
+        logger.info("Rotation token is already AWSCURRENT; skipping step %s", step)
         return
     if "AWSPENDING" not in version_stages:
         raise ValueError(f"Secret version {token} is not marked AWSPENDING")
@@ -34,25 +42,37 @@ def lambda_handler(event, context):
         finish_secret(arn, token, metadata)
     else:
         raise ValueError(f"Unknown rotation step {step}")
+    logger.info("Finished rotation step %s for secret %s", step, arn)
 
 
 def create_secret(arn, token):
+    logger.info("Checking whether AWSPENDING secret version already exists")
     try:
         secretsmanager.get_secret_value(
             SecretId=arn,
             VersionId=token,
             VersionStage="AWSPENDING",
         )
+        logger.info("AWSPENDING secret version already exists; not creating another key")
         return
     except secretsmanager.exceptions.ResourceNotFoundException:
+        logger.info("No AWSPENDING secret version exists yet")
         pass
 
     user_name = os.environ["IAM_USER_NAME"]
+    logger.info("Reading AWSCURRENT secret JSON")
     current_secret = get_secret_json(arn, "AWSCURRENT")
     current_access_key_id = current_secret.get("access_key_id")
+    logger.info(
+        "Current secret %s an access key id",
+        "has" if current_access_key_id else "does not have",
+    )
 
+    logger.info("Ensuring IAM user %s has capacity for a new access key", user_name)
     make_space_for_new_key(user_name, current_access_key_id)
+    logger.info("Creating new IAM access key for user %s", user_name)
     new_key = iam.create_access_key(UserName=user_name)["AccessKey"]
+    logger.info("Created new IAM access key %s", new_key["AccessKeyId"])
 
     pending_secret = {
         "access_key_id": new_key["AccessKeyId"],
@@ -62,21 +82,26 @@ def create_secret(arn, token):
         "prefix": os.environ["DAP_EXPORT_PREFIX"],
     }
 
+    logger.info("Writing new key metadata to AWSPENDING secret version")
     secretsmanager.put_secret_value(
         SecretId=arn,
         ClientRequestToken=token,
         SecretString=json.dumps(pending_secret),
         VersionStages=["AWSPENDING"],
     )
+    logger.info("Wrote AWSPENDING secret version")
 
 
 def test_secret(arn, token):
+    logger.info("Testing pending secret by checking IAM key status")
     pending_secret = get_secret_json(arn, "AWSPENDING", token)
     access_key_id = pending_secret["access_key_id"]
     user_name = os.environ["IAM_USER_NAME"]
 
+    logger.info("Listing IAM access keys for user %s", user_name)
     keys = iam.list_access_keys(UserName=user_name)["AccessKeyMetadata"]
     matching_keys = [key for key in keys if key["AccessKeyId"] == access_key_id]
+    logger.info("Found %d matching pending access keys", len(matching_keys))
     if len(matching_keys) != 1:
         raise ValueError("Pending access key was not found on the IAM user")
     if matching_keys[0]["Status"] != "Active":
@@ -84,6 +109,7 @@ def test_secret(arn, token):
 
 
 def finish_secret(arn, token, metadata):
+    logger.info("Finding current secret version before promotion")
     current_version = None
     for version, stages in metadata["VersionIdsToStages"].items():
         if "AWSCURRENT" in stages:
@@ -91,8 +117,10 @@ def finish_secret(arn, token, metadata):
             break
 
     if current_version == token:
+        logger.info("Pending token is already current; no promotion needed")
         return
 
+    logger.info("Promoting pending version to AWSCURRENT")
     secretsmanager.update_secret_version_stage(
         SecretId=arn,
         VersionStage="AWSCURRENT",
@@ -100,24 +128,32 @@ def finish_secret(arn, token, metadata):
         RemoveFromVersionId=current_version,
     )
 
+    logger.info("Reading AWSPREVIOUS secret to identify old key")
     old_access_key_id = get_secret_json(arn, "AWSPREVIOUS").get("access_key_id")
     if old_access_key_id:
+        logger.info("Deleting previous IAM access key %s", old_access_key_id)
         delete_access_key_if_present(os.environ["IAM_USER_NAME"], old_access_key_id)
+    else:
+        logger.info("No previous IAM access key found to delete")
 
 
 def get_secret_json(arn, stage, version_id=None):
+    logger.info("Reading secret stage %s", stage)
     args = {"SecretId": arn, "VersionStage": stage}
     if version_id:
         args["VersionId"] = version_id
     value = secretsmanager.get_secret_value(**args)
+    logger.info("Read secret stage %s", stage)
     return json.loads(value["SecretString"])
 
 
 def make_space_for_new_key(user_name, current_access_key_id):
+    logger.info("Listing existing access keys for user %s", user_name)
     keys = sorted(
         iam.list_access_keys(UserName=user_name)["AccessKeyMetadata"],
         key=lambda key: key["CreateDate"],
     )
+    logger.info("IAM user %s has %d access keys", user_name, len(keys))
     if len(keys) < 2:
         return
 
@@ -127,10 +163,15 @@ def make_space_for_new_key(user_name, current_access_key_id):
     if not removable_keys:
         raise ValueError("Cannot create a new access key because both existing keys are current")
 
+    logger.info("Deleting stale IAM access key %s to make room", removable_keys[0]["AccessKeyId"])
     delete_access_key_if_present(user_name, removable_keys[0]["AccessKeyId"])
 
 
 def delete_access_key_if_present(user_name, access_key_id):
+    logger.info("Checking whether access key %s exists for user %s", access_key_id, user_name)
     keys = iam.list_access_keys(UserName=user_name)["AccessKeyMetadata"]
     if any(key["AccessKeyId"] == access_key_id for key in keys):
         iam.delete_access_key(UserName=user_name, AccessKeyId=access_key_id)
+        logger.info("Deleted access key %s", access_key_id)
+    else:
+        logger.info("Access key %s is already absent", access_key_id)

--- a/terraform/modules/marklogic/dap_export_secret_rotation.py
+++ b/terraform/modules/marklogic/dap_export_secret_rotation.py
@@ -1,0 +1,136 @@
+import json
+import os
+
+import boto3
+
+iam = boto3.client("iam")
+secretsmanager = boto3.client("secretsmanager")
+
+
+def lambda_handler(event, context):
+    arn = event["SecretId"]
+    token = event["ClientRequestToken"]
+    step = event["Step"]
+
+    metadata = secretsmanager.describe_secret(SecretId=arn)
+    if not metadata.get("RotationEnabled"):
+        raise ValueError(f"Secret {arn} is not enabled for rotation")
+
+    version_stages = metadata["VersionIdsToStages"].get(token)
+    if version_stages is None:
+        raise ValueError(f"Secret version {token} has no stage for {arn}")
+    if "AWSCURRENT" in version_stages:
+        return
+    if "AWSPENDING" not in version_stages:
+        raise ValueError(f"Secret version {token} is not marked AWSPENDING")
+
+    if step == "createSecret":
+        create_secret(arn, token)
+    elif step == "setSecret":
+        return
+    elif step == "testSecret":
+        test_secret(arn, token)
+    elif step == "finishSecret":
+        finish_secret(arn, token, metadata)
+    else:
+        raise ValueError(f"Unknown rotation step {step}")
+
+
+def create_secret(arn, token):
+    try:
+        secretsmanager.get_secret_value(
+            SecretId=arn,
+            VersionId=token,
+            VersionStage="AWSPENDING",
+        )
+        return
+    except secretsmanager.exceptions.ResourceNotFoundException:
+        pass
+
+    user_name = os.environ["IAM_USER_NAME"]
+    current_secret = get_secret_json(arn, "AWSCURRENT")
+    current_access_key_id = current_secret.get("access_key_id")
+
+    make_space_for_new_key(user_name, current_access_key_id)
+    new_key = iam.create_access_key(UserName=user_name)["AccessKey"]
+
+    pending_secret = {
+        "access_key_id": new_key["AccessKeyId"],
+        "secret_access_key": new_key["SecretAccessKey"],
+        "region": os.environ["AWS_REGION_NAME"],
+        "bucket": os.environ["DAP_EXPORT_BUCKET"],
+        "prefix": os.environ["DAP_EXPORT_PREFIX"],
+    }
+
+    secretsmanager.put_secret_value(
+        SecretId=arn,
+        ClientRequestToken=token,
+        SecretString=json.dumps(pending_secret),
+        VersionStages=["AWSPENDING"],
+    )
+
+
+def test_secret(arn, token):
+    pending_secret = get_secret_json(arn, "AWSPENDING", token)
+    access_key_id = pending_secret["access_key_id"]
+    user_name = os.environ["IAM_USER_NAME"]
+
+    keys = iam.list_access_keys(UserName=user_name)["AccessKeyMetadata"]
+    matching_keys = [key for key in keys if key["AccessKeyId"] == access_key_id]
+    if len(matching_keys) != 1:
+        raise ValueError("Pending access key was not found on the IAM user")
+    if matching_keys[0]["Status"] != "Active":
+        raise ValueError("Pending access key is not active")
+
+
+def finish_secret(arn, token, metadata):
+    current_version = None
+    for version, stages in metadata["VersionIdsToStages"].items():
+        if "AWSCURRENT" in stages:
+            current_version = version
+            break
+
+    if current_version == token:
+        return
+
+    secretsmanager.update_secret_version_stage(
+        SecretId=arn,
+        VersionStage="AWSCURRENT",
+        MoveToVersionId=token,
+        RemoveFromVersionId=current_version,
+    )
+
+    old_access_key_id = get_secret_json(arn, "AWSPREVIOUS").get("access_key_id")
+    if old_access_key_id:
+        delete_access_key_if_present(os.environ["IAM_USER_NAME"], old_access_key_id)
+
+
+def get_secret_json(arn, stage, version_id=None):
+    args = {"SecretId": arn, "VersionStage": stage}
+    if version_id:
+        args["VersionId"] = version_id
+    value = secretsmanager.get_secret_value(**args)
+    return json.loads(value["SecretString"])
+
+
+def make_space_for_new_key(user_name, current_access_key_id):
+    keys = sorted(
+        iam.list_access_keys(UserName=user_name)["AccessKeyMetadata"],
+        key=lambda key: key["CreateDate"],
+    )
+    if len(keys) < 2:
+        return
+
+    removable_keys = [
+        key for key in keys if key["AccessKeyId"] != current_access_key_id
+    ]
+    if not removable_keys:
+        raise ValueError("Cannot create a new access key because both existing keys are current")
+
+    delete_access_key_if_present(user_name, removable_keys[0]["AccessKeyId"])
+
+
+def delete_access_key_if_present(user_name, access_key_id):
+    keys = iam.list_access_keys(UserName=user_name)["AccessKeyMetadata"]
+    if any(key["AccessKeyId"] == access_key_id for key in keys):
+        iam.delete_access_key(UserName=user_name, AccessKeyId=access_key_id)

--- a/terraform/modules/marklogic/providers.tf
+++ b/terraform/modules/marklogic/providers.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    time = {
+      source  = "hashicorp/time"
+      version = "~> 0.14.0"
+    }
+  }
+}

--- a/terraform/modules/marklogic/providers.tf
+++ b/terraform/modules/marklogic/providers.tf
@@ -1,8 +1,0 @@
-terraform {
-  required_providers {
-    time = {
-      source  = "hashicorp/time"
-      version = "~> 0.14.0"
-    }
-  }
-}

--- a/terraform/modules/marklogic/variables.tf
+++ b/terraform/modules/marklogic/variables.tf
@@ -21,6 +21,11 @@ variable "private_subnets" {
   description = "Three private subnets"
 }
 
+variable "dap_export_rotation_lambda_subnets" {
+  description = "Private subnets for the DAP export secret rotation Lambda"
+  default     = null
+}
+
 variable "private_dns" {
   type = object({
     zone_id     = string

--- a/terraform/modules/marklogic/variables.tf
+++ b/terraform/modules/marklogic/variables.tf
@@ -108,6 +108,16 @@ variable "s151_external_canonical_users" {
   type = list(string)
 }
 
+variable "dap_export_external_access" {
+  description = "External DAP export access configurations that create IAM users restricted to approved CIDRs"
+  type = list(object({
+    name          = string
+    allowed_cidrs = list(string)
+    rotation_days = number
+  }))
+  default = []
+}
+
 variable "marklogic_ami_version" {
   type = string
 

--- a/terraform/modules/marklogic/variables.tf
+++ b/terraform/modules/marklogic/variables.tf
@@ -113,7 +113,7 @@ variable "dap_export_external_access" {
   type = list(object({
     name          = string
     allowed_cidrs = list(string)
-    rotation_days = number
+    rotation_days = optional(number, 90)
   }))
   default = []
 }

--- a/terraform/modules/networking/main.tf
+++ b/terraform/modules/networking/main.tf
@@ -162,6 +162,14 @@ locals {
       sid_offset = 4100
       // Note that base rules use sid 5000+ 
     }
+    dap_export_rotation_lambda = {
+      cidr                 = local.dap_export_rotation_lambda_cidr_10
+      http_allowed_domains = []
+      tls_allowed_domains = [
+        "iam.amazonaws.com", # IAM has no VPC endpoint, required to rotate the generated access key
+      ]
+      sid_offset = 4200
+    }
   }
   firewalled_subnets = concat(
     aws_subnet.bastion_private_subnets,
@@ -175,6 +183,7 @@ locals {
     aws_subnet.mailhog,
     aws_subnet.jaspersoft,
     aws_subnet.auth_service,
+    [aws_subnet.dap_export_rotation_lambda],
     [aws_subnet.ldaps_ca_server, aws_subnet.ad_management_server, aws_subnet.github_runner]
   )
 

--- a/terraform/modules/networking/outputs.tf
+++ b/terraform/modules/networking/outputs.tf
@@ -85,6 +85,11 @@ output "auth_service_private_subnets" {
   description = "Private /24 subnets for auth service"
 }
 
+output "dap_export_rotation_lambda_subnets" {
+  value       = [aws_subnet.dap_export_rotation_lambda]
+  description = "Private subnet for DAP export secret rotation Lambda"
+}
+
 output "private_dns" {
   value = {
     zone_id     = aws_route53_zone.private.zone_id

--- a/terraform/modules/networking/secrets_manager_interface.tf
+++ b/terraform/modules/networking/secrets_manager_interface.tf
@@ -20,7 +20,12 @@ resource "aws_vpc_endpoint" "secrets_manager" {
 # Note that endpoint policies only limit access, credentials to access a given secret are still required
 data "aws_iam_policy_document" "secret_manager_endpoint" {
   statement {
-    actions = ["secretsmanager:GetSecretValue", "secretsmanager:DescribeSecret"]
+    actions = [
+      "secretsmanager:DescribeSecret",
+      "secretsmanager:GetSecretValue",
+      "secretsmanager:PutSecretValue",
+      "secretsmanager:UpdateSecretVersionStage",
+    ]
     principals {
       type        = "AWS"
       identifiers = [data.aws_caller_identity.current.account_id]

--- a/terraform/modules/networking/subnet.tf
+++ b/terraform/modules/networking/subnet.tf
@@ -19,6 +19,7 @@ locals {
   website_db_cidr_10                  = cidrsubnet(aws_vpc.vpc.cidr_block, 6, 13)  # 52.0/22
   auth_service_cidr_10                = cidrsubnet(aws_vpc.vpc.cidr_block, 6, 14)  # 56.0/22
   ml_restore_rehearsal_subnet_cidr_10 = cidrsubnet(aws_vpc.vpc.cidr_block, 6, 15)  # 60.0/22
+  dap_export_rotation_lambda_cidr_10  = cidrsubnet(aws_vpc.vpc.cidr_block, 6, 16)  # 64.0/22
   public_cidr_10                      = cidrsubnet(aws_vpc.vpc.cidr_block, 6, 32)  # 128.0/22
   firewall_cidr_8                     = cidrsubnet(aws_vpc.vpc.cidr_block, 8, 254) # 254.0/24
   nat_gateway_cidr_8                  = cidrsubnet(aws_vpc.vpc.cidr_block, 8, 255) # 255.0/24
@@ -198,4 +199,12 @@ resource "aws_subnet" "auth_service" {
   availability_zone       = data.aws_availability_zones.available.names[count.index]
   map_public_ip_on_launch = false
   tags                    = { Name = "auth-service-private-subnet-${data.aws_availability_zones.available.names[count.index]}-${var.environment}" }
+}
+
+resource "aws_subnet" "dap_export_rotation_lambda" {
+  cidr_block              = cidrsubnet(local.dap_export_rotation_lambda_cidr_10, 2, 0)
+  vpc_id                  = aws_vpc.vpc.id
+  availability_zone       = data.aws_availability_zones.available.names[0]
+  map_public_ip_on_launch = false
+  tags                    = { Name = "dap-export-rotation-lambda-private-subnet-${var.environment}" }
 }

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -302,14 +302,15 @@ data "aws_route53_zone" "private" {
 module "marklogic" {
   source = "../modules/marklogic"
 
-  default_tags             = var.default_tags
-  environment              = local.environment
-  vpc                      = module.networking.vpc
-  private_subnets          = module.networking.ml_private_subnets
-  instance_type            = "t3a.2xlarge"
-  marklogic_ami_version    = "11.3.3"
-  private_dns              = module.networking.private_dns
-  patch_maintenance_window = module.marklogic_patch_maintenance_window
+  default_tags                       = var.default_tags
+  environment                        = local.environment
+  vpc                                = module.networking.vpc
+  private_subnets                    = module.networking.ml_private_subnets
+  dap_export_rotation_lambda_subnets = module.networking.dap_export_rotation_lambda_subnets
+  instance_type                      = "t3a.2xlarge"
+  marklogic_ami_version              = "11.3.3"
+  private_dns                        = module.networking.private_dns
+  patch_maintenance_window           = module.marklogic_patch_maintenance_window
   data_volume = {
     size_gb                = 200
     iops                   = 3000

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -331,7 +331,6 @@ module "marklogic" {
     {
       name          = "azure-dap-export"
       allowed_cidrs = var.azure_dap_export_allowed_cidrs
-      rotation_days = 90
     }
   ]
   dap_job_notification_emails            = local.all_notifications_email_addresses

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -331,7 +331,7 @@ module "marklogic" {
     {
       name          = "azure-dap-export"
       allowed_cidrs = var.azure_dap_export_allowed_cidrs
-      rotation_days = 180
+      rotation_days = 90
     }
   ]
   dap_job_notification_emails            = local.all_notifications_email_addresses

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -327,18 +327,25 @@ module "marklogic" {
   data_disk_usage_alarm_threshold_percent = 70
   dap_external_role_arns                  = var.dap_external_role_arns
   s151_external_canonical_users           = var.s151_external_canonical_users
-  dap_job_notification_emails             = local.all_notifications_email_addresses
-  backup_replication_bucket               = module.backup_replication_bucket.bucket
-  ebs_backup_role_arn                     = module.ebs_backup.role_arn
-  ebs_backup_completed_sns_topic_arn      = module.ebs_backup.sns_topic_arn
-  iam_github_openid_connect_provider_arn  = data.aws_iam_openid_connect_provider.github.arn
-  ses_deploy_secret_arns                  = [module.delta_ses_user.deploy_secret_arn, module.cpm_ses_user.deploy_secret_arn]
-  create_dns_record                       = true
-  zone_id                                 = data.aws_route53_zone.private.zone_id
-  marklogic_host_name1                    = "${local.environment}-ml1.${data.aws_route53_zone.private.name}"
-  marklogic_host_name2                    = "${local.environment}-ml2.${data.aws_route53_zone.private.name}"
-  marklogic_host_name3                    = "${local.environment}-ml3.${data.aws_route53_zone.private.name}"
-  ami_id                                  = "ami-0ec1c288dc6b713b9"
+  dap_export_external_access = length(var.azure_dap_export_allowed_cidrs) == 0 ? [] : [
+    {
+      name          = "azure-dap-export"
+      allowed_cidrs = var.azure_dap_export_allowed_cidrs
+      rotation_days = 180
+    }
+  ]
+  dap_job_notification_emails            = local.all_notifications_email_addresses
+  backup_replication_bucket              = module.backup_replication_bucket.bucket
+  ebs_backup_role_arn                    = module.ebs_backup.role_arn
+  ebs_backup_completed_sns_topic_arn     = module.ebs_backup.sns_topic_arn
+  iam_github_openid_connect_provider_arn = data.aws_iam_openid_connect_provider.github.arn
+  ses_deploy_secret_arns                 = [module.delta_ses_user.deploy_secret_arn, module.cpm_ses_user.deploy_secret_arn]
+  create_dns_record                      = true
+  zone_id                                = data.aws_route53_zone.private.zone_id
+  marklogic_host_name1                   = "${local.environment}-ml1.${data.aws_route53_zone.private.name}"
+  marklogic_host_name2                   = "${local.environment}-ml2.${data.aws_route53_zone.private.name}"
+  marklogic_host_name3                   = "${local.environment}-ml3.${data.aws_route53_zone.private.name}"
+  ami_id                                 = "ami-0ec1c288dc6b713b9"
 
 }
 

--- a/terraform/staging/variables.tf
+++ b/terraform/staging/variables.tf
@@ -64,3 +64,8 @@ variable "s151_external_canonical_users" {
   default     = ["4a20e1ecba266786127536b068cbbf222b344a2e21024029f1a778f98e8667c0", "5544757b63b565e6774e61121ba15cfa98206f1629455df924f60d942a861d56"]
 }
 
+variable "azure_dap_export_allowed_cidrs" {
+  type        = list(string)
+  description = "Azure partner CIDRs allowed to use the staging DAP export access key"
+  default     = ["4.158.35.41/32"]
+}


### PR DESCRIPTION
Creates rotating credentials to allow DAP S3 bucket access from specified IP.

- rotating secret using lambda function (with own vpc to allow egress to IAM)
- IAM user with credentials stored in secret manager who can access resources 
- IAM user is IP restricted

Tested again own IP address, I can access resources using credentials. (I cannot when IP does not match).