### PR TITLE
fix(marklogic): upgrade AL2023 release during patch windows

### DIFF
--- a/terraform/modules/marklogic/patch.sh
+++ b/terraform/modules/marklogic/patch.sh
@@ -35,8 +35,15 @@ if [[ "InService" == $LIFECYCLE_STATE ]]; then
     echo "Current state: $${LIFECYCLE_STATE}"
   done
   
-  echo "Running yum update"
-  yum update --security -y
+  # AL2023 version-locks package repos to the installed system-release. In-version
+  # `yum update --security` often reports "Nothing to do" while newer releases
+  # contain kernel/security fixes (e.g. CVE-2026-43499 / ALAS2023-2026-1753).
+  # `dnf check-release-update` lists many intermediate versions on stderr and is
+  # awkward to parse; `--releasever=latest` upgrades to the newest available.
+  echo "Checking for Amazon Linux release updates (informational)"
+  dnf check-release-update 2>&1 || true
+  echo "Upgrading Amazon Linux to latest available release"
+  dnf upgrade --releasever=latest -y
   echo "Updates complete, requesting reboot from SSM agent at $(date --iso-8601=seconds)"
   exit 194 # Reboot and re-run the script https://docs.aws.amazon.com/systems-manager/latest/userguide/send-commands-reboot.html
 fi

--- a/terraform/modules/marklogic/patching.tf
+++ b/terraform/modules/marklogic/patching.tf
@@ -74,8 +74,8 @@ resource "aws_ssm_maintenance_window_task" "ml_patch" {
 
   task_invocation_parameters {
     run_command_parameters {
-      comment         = "Yum update security"
-      timeout_seconds = 1800
+      comment         = "AL2023 release upgrade / security updates"
+      timeout_seconds = 3600
 
       service_role_arn = var.patch_maintenance_window.service_role_arn
       notification_config {


### PR DESCRIPTION
In-version yum update --security no-ops on AL2023 while newer releases contain kernel fixes such as CVE-2026-43499. Use dnf upgrade --releasever=latest and allow longer SSM task timeouts.