### PR TITLE
Use m6a instance types for MarkLogic on 11.3.6 AMI

### DIFF
--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -290,7 +290,7 @@ module "marklogic" {
   vpc                                = module.networking.vpc
   private_subnets                    = module.networking.ml_private_subnets
   dap_export_rotation_lambda_subnets = module.networking.dap_export_rotation_lambda_subnets
-  instance_type                      = "t3a.2xlarge"
+  instance_type                      = "m6a.2xlarge"
   marklogic_ami_version              = "11.3.6"
   private_dns                        = module.networking.private_dns
   patch_maintenance_window           = module.marklogic_patch_maintenance_window

--- a/terraform/test/main.tf
+++ b/terraform/test/main.tf
@@ -295,7 +295,7 @@ module "marklogic" {
   environment              = local.environment
   vpc                      = module.networking.vpc
   private_subnets          = module.networking.ml_private_subnets
-  instance_type            = "t3a.large"
+  instance_type            = "m6a.xlarge"
   marklogic_ami_version    = "11.3.6"
   private_dns              = module.networking.private_dns
   patch_maintenance_window = module.marklogic_patch_maintenance_window


### PR DESCRIPTION
The new Marketplace product for the 11.3.6 AMI does not support t3a; switch test and staging to allowed m6a equivalents.