### PR TITLE
DELTA-43948--support-mailto-via-infra-fix

### DIFF
--- a/terraform/modules/cloudfront_website/503.html
+++ b/terraform/modules/cloudfront_website/503.html
@@ -8573,7 +8573,7 @@
                 <div class="govuk-grid-row">
                     <div class="govuk-grid-column-full">
                         <p>The Delta website is currently unavailable. Please try again later.</p>
-                        <p>If you need support urgently, please <a href="mailto:dluhc.digital-services@levellingup.gov.uk">contact the Service desk</a>.</p>
+                        <p>If you need support urgently, please <a href="mailto:svc-delta-help@communities.gov.uk">contact the Service desk</a>.</p>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Updates the CloudFront 503 Website Unavailable page so contact the Service desk emails svc-delta-help@communities.gov.uk instead of the old dluhc.digital-services@levellingup.gov.uk address.

Needs a terraform apply so static_errors/503.html is refreshed in the error-page bucket. Confirm the mailto in terraform/modules/cloudfront_website/503.html, or check the live 503 page when the origin is unavailable.


https://delta.test.communities.gov.uk/static_errors/503.html
https://delta.stage.communities.gov.uk/static_errors/503.html