### PR TITLE
Ignore NoEcho CloudFormation password params on MarkLogic stack

### DIFF
--- a/terraform/modules/marklogic/marklogic_stack.tf
+++ b/terraform/modules/marklogic/marklogic_stack.tf
@@ -65,9 +65,8 @@ resource "aws_cloudformation_stack" "marklogic" {
     # prevent_destroy = true
     ignore_changes = [
       # Otherwise Terraform always detects NoEcho CF parameters as changed
-      #parameters["AdminPass"],
-
-      # parameters["LicenseKey"]
+      parameters["AdminPass"],
+      parameters["LicenseKey"]
     ]
   }
   depends_on = [aws_iam_role_policy_attachment.ml_attach]


### PR DESCRIPTION
Stop Terraform from detecting drift on AdminPass and LicenseKey, which CloudFormation masks and Secrets Manager may rotate outside Terraform.