### PR TITLE
DT-2952: wait for instance credentials in MarkLogic patch scripts

### DIFF
--- a/terraform/modules/marklogic/final_forest_state.sh
+++ b/terraform/modules/marklogic/final_forest_state.sh
@@ -5,6 +5,22 @@ set -euo pipefail
 echo "Starting final forest state script at $(date --iso-8601=seconds)"
 echo "Checking if all forests are in the correct state"
 
+export AWS_REGION=${AWS_REGION}
+export AWS_DEFAULT_REGION=${AWS_REGION}
+
+# This runs shortly after the patch reboot, when IMDS may not be serving instance
+# profile credentials yet. The CLI defaults of a 1 second timeout and a single attempt
+# then fail as NoCredentials, and set -e aborts before the forests are checked.
+export AWS_METADATA_SERVICE_TIMEOUT=10
+export AWS_METADATA_SERVICE_NUM_ATTEMPTS=5
+
+echo "Waiting for instance credentials"
+for _ in $(seq 1 30); do
+  aws sts get-caller-identity > /dev/null 2>&1 && break
+  sleep 10
+done
+aws sts get-caller-identity > /dev/null
+
 ML_USER_PASS=$(aws secretsmanager get-secret-value --secret-id ml-admin-user-${ENVIRONMENT} --region ${AWS_REGION} --query SecretString --output text)
 ML_USER=$(echo $ML_USER_PASS | jq -r '.username')
 ML_PASS=$(echo $ML_USER_PASS | jq -r '.password')

--- a/terraform/modules/marklogic/patch.sh
+++ b/terraform/modules/marklogic/patch.sh
@@ -5,6 +5,22 @@ set -euo pipefail
 echo "Starting patch script at $(date --iso-8601=seconds)"
 
 export AWS_REGION=${AWS_REGION}
+export AWS_DEFAULT_REGION=${AWS_REGION}
+
+# The SSM agent re-runs this script during boot after the exit 194 reboot, when IMDS
+# may not be serving instance profile credentials yet. The CLI defaults of a 1 second
+# timeout and a single attempt then fail as NoCredentials, and set -e aborts the run
+# before the instance is taken back out of standby.
+export AWS_METADATA_SERVICE_TIMEOUT=10
+export AWS_METADATA_SERVICE_NUM_ATTEMPTS=5
+
+echo "Waiting for instance credentials"
+for _ in $(seq 1 30); do
+  aws sts get-caller-identity > /dev/null 2>&1 && break
+  sleep 10
+done
+aws sts get-caller-identity > /dev/null
+
 TOKEN=`curl -sS -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600"`
 INSTANCE_ID=`curl -sS -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/instance-id`
 AUTOSCALING_GROUP_NAME=`aws autoscaling describe-auto-scaling-instances --instance-ids $INSTANCE_ID --query 'AutoScalingInstances[0].AutoScalingGroupName' --output text`

--- a/terraform/modules/marklogic/restart_server.sh
+++ b/terraform/modules/marklogic/restart_server.sh
@@ -4,6 +4,22 @@ set -euo pipefail
 
 echo "Starting restart server script at $(date --iso-8601=seconds)"
 
+export AWS_REGION=${AWS_REGION}
+export AWS_DEFAULT_REGION=${AWS_REGION}
+
+# This runs shortly after the patch reboot, when IMDS may not be serving instance
+# profile credentials yet. The CLI defaults of a 1 second timeout and a single attempt
+# then fail as NoCredentials, and set -e aborts before MarkLogic is restarted.
+export AWS_METADATA_SERVICE_TIMEOUT=10
+export AWS_METADATA_SERVICE_NUM_ATTEMPTS=5
+
+echo "Waiting for instance credentials"
+for _ in $(seq 1 30); do
+  aws sts get-caller-identity > /dev/null 2>&1 && break
+  sleep 10
+done
+aws sts get-caller-identity > /dev/null
+
 ML_USER_PASS=$(aws secretsmanager get-secret-value --secret-id ml-admin-user-${ENVIRONMENT} --region ${AWS_REGION} --query SecretString --output text)
 ML_USER=$(echo $ML_USER_PASS | jq -r '.username')
 ML_PASS=$(echo $ML_USER_PASS | jq -r '.password')


### PR DESCRIPTION
Avoid NoCredentials failures after the SSM exit-194 reboot when IMDS is not yet serving the instance profile, which left nodes stuck in standby.